### PR TITLE
Power BI report catalog with link

### DIFF
--- a/PowerBI-Reports.md
+++ b/PowerBI-Reports.md
@@ -1,0 +1,12 @@
+# 📊 Power BI Reports Catalog
+This document contains links to Power BI reports published in Power BI Service.
+---
+## 🔹 InfraOps Performance Dashboard
+- 🔗 Link: [https://app.powerbi.com/your-link](https://app.powerbi.com/links/V4jTwvOGQC?ctid=b859cf7e-ff8a-40bb-bd0f-da56e6dc0eb8&pbi_source=linkShare&bookmarkGuid=a27756fd-413f-4ed3-b71a-1c6ba6aea01c)
+- 📌 Description: Tracks infra operations performance- incidents, ITSR
+- 🔄 Refresh Frequency: 8 hours
+- 👤 Owner: Rekha Sharma
+---
+## 🔹 Notes
+- PBIX files are not uploaded due to large file size (>3GB).
+- Reports are accessible within the organization via Power BI Service


### PR DESCRIPTION
Added a Power BI reports catalog (PowerBI-Reports.md) with report links.
PBIX files are not included due to large size (>3GB).
Reports are accessible via Power BI Service within the organization.
