### PR TITLE
Move all Fabric data sources to Lakehouse + fix license filter dynamics

### DIFF
--- a/Fabric/README.md
+++ b/Fabric/README.md
@@ -8,8 +8,10 @@ This is the **fastest, most reliable** way to run the AI-in-One Dashboard on rea
 
 | File | Purpose |
 |---|---|
-| `AI-in-One Dashboard - Fabric.pbit` | The Power BI template (thin client — sources from a Lakehouse SQL endpoint) |
-| `notebooks/Copilot_Audit_Log_Parser.ipynb` | The PySpark notebook that parses raw audit logs into a flat Delta table |
+| `AI-in-One Dashboard - Fabric.pbit` | The Power BI template (thin client — sources all three input tables from a Lakehouse SQL endpoint) |
+| `notebooks/Copilot_Audit_Log_Parser.ipynb` | Parses raw audit logs → `dbo.copilot_interactions_parsed` |
+| `notebooks/Copilot_Licensed_Users_Loader.ipynb` | Ingests MAC licensed-user CSVs → `dbo.copilot_licensed_users` |
+| `notebooks/Copilot_Org_Data_Loader.ipynb` | Ingests Entra/HRIS org CSVs → `dbo.copilot_org_data` |
 
 ## When to use this path
 
@@ -33,20 +35,28 @@ Moving the parse into Fabric eliminates all three. The dataset becomes a thin pa
 ## Architecture
 
 ```
-Raw audit-log CSVs (from scripts/get-copilot-interactions.ps1
-                     or your own export pipeline)
-                              ↓
-                  Fabric Lakehouse: Files/audit_raw/
-                              ↓
-              Notebook: Copilot_Audit_Log_Parser.ipynb
-                  (runs on schedule via Fabric pipelines)
-                              ↓
-       Lakehouse Delta table: dbo.Copilot_Interactions_Parsed
-                              ↓
-                    PBIT (Sql.Database connector)
-                              ↓
-                       Power BI Report
+Raw audit-log CSVs       Licensed-users CSV         Org-data CSV
+(get-copilot-            (MAC export)               (Entra / HRIS)
+ interactions.ps1
+ or your pipeline)
+        ↓                       ↓                        ↓
+Files/audit_raw/         Files/licensed_raw/        Files/org_raw/
+        ↓                       ↓                        ↓
+Copilot_Audit_Log_       Copilot_Licensed_          Copilot_Org_Data_
+Parser.ipynb             Users_Loader.ipynb         Loader.ipynb
+        ↓                       ↓                        ↓
+dbo.copilot_             dbo.copilot_               dbo.copilot_
+interactions_parsed      licensed_users             org_data
+        └───────────────────────┴────────────────────────┘
+                                ↓
+                  PBIT (Sql.Database connector
+                  + one direct Org→Licensed
+                  relationship for filter context)
+                                ↓
+                        Power BI Report
 ```
+
+The PBIT only requires two parameters: **Fabric SQL Endpoint** and **Lakehouse Database**. The previous file-path parameters (`Copilot Licensed Users`, `Org Data File`, `Copilot Interactions File`) are kept for backward compatibility but should be left blank when running this Fabric path — the notebooks own those data sources now. Only `Agent 365` still uses a file-path parameter (a CSV export from MAC), pending a Graph API loader.
 
 ## Quick start
 
@@ -56,41 +66,53 @@ Raw audit-log CSVs (from scripts/get-copilot-interactions.ps1
 - **+ New → Lakehouse**, name it e.g. `CopilotAnalytics`
 - Note the **SQL endpoint** under Lakehouse settings — looks like `<workspace-guid>.datawarehouse.fabric.microsoft.com`
 
-### 2. Land raw audit CSVs in `Files/audit_raw/`
+### 2. Land raw CSVs in three Lakehouse `Files/` sub-folders
 
-The CSVs must have the standard Microsoft 365 audit-log columns:
-`RecordId, CreationDate, RecordType, Operation, AuditData, AssociatedAdminUnits, AssociatedAdminUnitsNames`
+Create the folders if they don't exist (right-click `Files` → **New folder**), then drop the corresponding CSVs in:
 
-Pick whichever ingestion path fits your environment:
+| Folder | Source | Required columns |
+|---|---|---|
+| `Files/audit_raw/` | M365 audit-log export (e.g. [`scripts/get-copilot-interactions.ps1`](../scripts/get-copilot-interactions.ps1) or any other audit pipeline) | `RecordId, CreationDate, RecordType, Operation, AuditData, AssociatedAdminUnits, AssociatedAdminUnitsNames` |
+| `Files/licensed_raw/` | MAC export of Copilot-licensed users | A UPN column (`User Principal Name`, `userPrincipalName`, `UserPrincipalName`, `User principal name`) and a licence column (`Has license`, `Has Licence`, `HasLicense`, `HasCopilot`, `Has Copilot License`, `Has Copilot license assigned`, `isUser`, etc.). The loader auto-detects which variant your export uses. |
+| `Files/org_raw/` | Entra / HRIS / Viva Insights export with org structure | A PersonId column (`User Principal Name` / `UPN` / `PersonId`) plus a `Department` column. Optional: `JobTitle`, `DisplayName`, `Email`, `Country`, plus any management-path / hierarchy columns you want to slice by. |
 
-| If your audit export goes to… | Use… |
+For each, pick whichever ingestion path fits your environment:
+
+| If your export goes to… | Use… |
 |---|---|
 | SharePoint folder | A **Fabric Pipeline** with a Copy activity (SharePoint Online → Lakehouse Files) |
 | Azure Blob Storage / ADLS Gen2 | A **Lakehouse Shortcut** to the storage container (no copy needed) |
 | Local files | Direct upload via the Fabric portal, or pipeline Copy activity |
 
-The existing [`scripts/get-copilot-interactions.ps1`](../scripts/get-copilot-interactions.ps1) writes CSV output that drops in directly.
+### 3. Import and run all three notebooks
 
-### 3. Import and run the parser notebook
+For each of the three notebooks under `notebooks/`:
 
-- In your Fabric workspace → **+ New → Import notebook** → upload [`notebooks/Copilot_Audit_Log_Parser.ipynb`](notebooks/Copilot_Audit_Log_Parser.ipynb)
-- Attach the notebook to your Lakehouse (top-left **+ Lakehouse** → select `CopilotAnalytics`)
-- Click **Run all**. First run typically takes 30–60 seconds for ~400K events
-- Output: a Delta table called `Copilot_Interactions_Parsed` in the Lakehouse Tables folder
-- Configure **Schedule** (top of notebook) to match your audit-log export cadence (typically daily)
+- In your Fabric workspace → **+ New → Import notebook** → upload the `.ipynb`
+- Attach the notebook to your `CopilotAnalytics` Lakehouse and **pin it as default** (📌 icon next to the name in the Lakehouses panel — this is what makes `saveAsTable` write to the right place)
+- Click **Run all**
+
+| Notebook | Run cadence | Output Delta table | Typical runtime |
+|---|---|---|---|
+| `Copilot_Audit_Log_Parser.ipynb` | Daily (matches audit-log export) | `dbo.copilot_interactions_parsed` | 30–60s for ~400K events |
+| `Copilot_Licensed_Users_Loader.ipynb` | Weekly / monthly (matches MAC export cadence) | `dbo.copilot_licensed_users` | Seconds |
+| `Copilot_Org_Data_Loader.ipynb` | Weekly (matches HRIS / Entra refresh) | `dbo.copilot_org_data` | Seconds |
+
+Use the **Schedule** button at the top of each notebook to set a cadence — or wire all three into a single Fabric Pipeline.
 
 ### 4. Connect the PBIT
 
 - Open `AI-in-One Dashboard - Fabric.pbit` in Power BI Desktop
-- Supply the two parameters when prompted:
+- Supply the two **required** parameters when prompted; leave the rest blank:
 
 | Parameter | Value |
 |---|---|
 | **Fabric SQL Endpoint** | `<workspace-guid>.datawarehouse.fabric.microsoft.com` |
 | **Lakehouse Database** | `CopilotAnalytics` (or whatever you named your Lakehouse) |
-| Copilot Licensed Users | Path to your licensed-users CSV (or a SharePoint URL) |
-| Org Data File | Path to your org-data CSV (or a SharePoint URL) |
-| Optional ones | Leave blank |
+| Copilot Interactions File | Leave blank — vestigial |
+| Copilot Licensed Users | Leave blank — sourced from `dbo.copilot_licensed_users` |
+| Org Data File | Leave blank — sourced from `dbo.copilot_org_data` |
+| Agent 365 (highly recommended) | Path to your Agents 365 CSV (still file-based pending Graph API loader) |
 
 - Click **Load**. Refresh should complete in seconds
 - Publish to a Power BI workspace ideally **on the same Fabric capacity** so Direct Lake works without cross-capacity overhead
@@ -149,7 +171,10 @@ The PBIT only cares that a table called `dbo.Copilot_Interactions_Parsed` (or wh
 |---|---|---|
 | Refresh succeeds but interactions table is empty | Parsing notebook hasn't run yet, or failed silently | Check the notebook's last execution; run manually |
 | `Login failed` / `cannot open database` | SQL endpoint hostname or database name wrong | Re-check Lakehouse settings page for the exact SQL endpoint string |
-| `Formula.Firewall` error | Cross-source merge with privacy levels mismatched | Service → dataset Settings → Data source credentials → set **Privacy: None** for both sources |
+| `the key didn't match any rows in the table` | A loader notebook ran against the wrong (non-default) lakehouse, so the expected table name doesn't exist | In the notebook's Lakehouses panel, confirm `CopilotAnalytics` is **pinned** (📌) before re-running |
+| All users show as "Unlicensed" / `Total Licensed Users` empty | Licensed-users notebook hasn't been run yet, or its CSV used a UPN column-name variant the loader doesn't recognise | Check the notebook output for the detected UPN/licence column names; widen the variant list in the loader if needed |
+| `Inactive Licensed Users` is 0 even with no filter | Every licensed user has audit activity (likely with synthetic / test data); or `UPN_Normalized` ↔ `PersonId_Normalized` casing mismatch | Run `SELECT COUNT(*) FROM dbo.copilot_licensed_users WHERE UPN_Normalized NOT IN (SELECT LOWER(LTRIM(RTRIM(Audit_UserId))) FROM dbo.copilot_interactions_parsed)` — if result is 0, your population is genuinely fully active |
+| `Formula.Firewall` error (only on non-Fabric variants) | Cross-source merge with privacy levels mismatched | Service → dataset Settings → Data source credentials → set **Privacy: None** for both sources |
 | Only some columns populated | Microsoft added new fields to the audit schema | Update `audit_schema` in the notebook (cell 2) to include them, re-run |
 | Refresh slow (more than a minute) | Dataset is in Import mode | Switch the workspace to a Fabric capacity and convert to **Direct Lake** for sub-second response |
 

--- a/Fabric/notebooks/Copilot_Licensed_Users_Loader.ipynb
+++ b/Fabric/notebooks/Copilot_Licensed_Users_Loader.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Copilot Licensed Users Loader\n",
+    "\n",
+    "Ingests one or more **Copilot licensed user list** CSVs (typically exported from MAC) into a flat Delta table consumed by the **AI-in-One Dashboard** and **AI Business Value Dashboard** Fabric variants.\n",
+    "\n",
+    "**Inputs**: CSV(s) landed in `Files/licensed_raw/` of this Lakehouse. Accepted UPN column names: `User Principal Name`, `userPrincipalName`, `UserPrincipalName`, `User principal name`. Accepted licence column names: `Has license`, `Has Licence`, `HasLicense`, `HasCopilot`, `Has Copilot License`, `Has Copilot license assigned`, `isUser`, etc.\n",
+    "\n",
+    "**Output**: Lakehouse Delta table `dbo.copilot_licensed_users`. Delta tables disallow spaces / `,;{}()\\n\\t=` in column names, so the loader sanitises all column names to underscore-safe form (`User Principal Name` → `User_Principal_Name`, `Has license` → `Has_license`, `Report Refresh Date` → `Report_Refresh_Date`, etc.). The PBIT's `sourceColumn` references are aligned with these names.\n",
+    "\n",
+    "**Schedule**: run on the same cadence as your licence export (typically weekly/monthly).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RAW_PATH     = 'Files/licensed_raw/*.csv'         # raw licence-export CSVs\n",
+    "OUTPUT_TABLE = 'copilot_licensed_users'           # Delta table consumed by the PBIT\n",
+    "WRITE_MODE   = 'overwrite'                        # 'overwrite' for full snapshots; switch to 'append' if appending"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Read raw CSVs and detect column variants\n",
+    "Mirrors the M-query renaming logic so users dropping different MAC export shapes still produce the same Delta schema."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "raw = (spark.read\n",
+    "    .option('header', 'true')\n",
+    "    .option('multiline', 'true')\n",
+    "    .option('escape', '\"')\n",
+    "    .csv(RAW_PATH))\n",
+    "\n",
+    "print(f'Raw rows: {raw.count():,}')\n",
+    "print('Detected columns:', raw.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Column-variant detection — find the actual UPN and Has-license columns\n",
+    "upn_variants = ['User Principal Name', 'userPrincipalName', 'UserPrincipalName', 'User principal name']\n",
+    "license_variants = [\n",
+    "    'Has license', 'Has License', 'Has Licence', 'Has licence',\n",
+    "    'HasLicense', 'HasCopilot', 'Has Copilot', 'Has Copilot License',\n",
+    "    'Has Copilot license', 'HasCopilotLicense',\n",
+    "    'Has Copilot License Assigned', 'Has Copilot license assigned',\n",
+    "    'isUser'\n",
+    "]\n",
+    "\n",
+    "actual_upn     = next((c for c in upn_variants     if c in raw.columns), None)\n",
+    "actual_license = next((c for c in license_variants if c in raw.columns), None)\n",
+    "\n",
+    "print(f'UPN column detected:      {actual_upn}')\n",
+    "print(f'Licence column detected:  {actual_license}')\n",
+    "\n",
+    "df = raw\n",
+    "\n",
+    "# Rename UPN variant to canonical 'User Principal Name' (then we sanitize below)\n",
+    "if actual_upn is None:\n",
+    "    df = df.withColumn('User Principal Name', F.lit(None).cast('string'))\n",
+    "elif actual_upn != 'User Principal Name':\n",
+    "    df = df.withColumnRenamed(actual_upn, 'User Principal Name')\n",
+    "\n",
+    "# Rename licence variant to canonical 'Has license'\n",
+    "if actual_license is None:\n",
+    "    df = df.withColumn('Has license', F.lit('Unknown'))\n",
+    "elif actual_license != 'Has license':\n",
+    "    df = df.withColumnRenamed(actual_license, 'Has license')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Add normalized join key + dedupe"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df.withColumn(\n",
+    "    'UPN_Normalized',\n",
+    "    F.when(F.col('`User Principal Name`').isNull(), None)\n",
+    "     .otherwise(F.lower(F.trim(F.col('`User Principal Name`').cast('string'))))\n",
+    ")\n",
+    "\n",
+    "# Dedupe on the normalized key — keep first row per UPN_Normalized\n",
+    "df = df.dropDuplicates(['UPN_Normalized'])\n",
+    "\n",
+    "print(f'After dedupe: {df.count():,} rows')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Sanitize column names for Delta\n",
+    "Delta rejects column names containing ` ,;{}()\\n\\t=`. Replace each invalid character with `_` (e.g. `User Principal Name` → `User_Principal_Name`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_INVALID = re.compile(r'[ ,;{}()\\n\\t=]')\n",
+    "\n",
+    "def sanitize(name: str) -> str:\n",
+    "    return _INVALID.sub('_', name)\n",
+    "\n",
+    "df = df.toDF(*[sanitize(c) for c in df.columns])\n",
+    "print('Sanitized columns:', df.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Write to Lakehouse Delta table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(df.write\n",
+    "    .format('delta')\n",
+    "    .mode(WRITE_MODE)\n",
+    "    .option('overwriteSchema', 'true')\n",
+    "    .saveAsTable(OUTPUT_TABLE))\n",
+    "\n",
+    "print(f'Rows written to {OUTPUT_TABLE}: {spark.table(OUTPUT_TABLE).count():,}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Verify\n",
+    "Spot-check the output. Expect every row to have `UPN_Normalized` populated and a non-null `Has_license`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.table(OUTPUT_TABLE).select(\n",
+    "    'User_Principal_Name', 'Has_license', 'UPN_Normalized'\n",
+    ").show(10, truncate=False)\n",
+    "\n",
+    "spark.table(OUTPUT_TABLE).groupBy('Has_license').count().orderBy(F.desc('count')).show(20, truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "**Connect the PBIT**: this table is consumed by the `Copilot Licensed` query in the AI-in-One and AI Business Value dashboards. Once this notebook has run, you can leave the `Copilot Licensed Users` parameter blank when opening the PBIT — refresh will source from `dbo.copilot_licensed_users` directly via the Fabric SQL endpoint."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Synapse PySpark",
+   "language": "Python",
+   "name": "synapse_pyspark"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Fabric/notebooks/Copilot_Org_Data_Loader.ipynb
+++ b/Fabric/notebooks/Copilot_Org_Data_Loader.ipynb
@@ -1,0 +1,220 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Copilot Org Data Loader\n",
+    "\n",
+    "Ingests one or more **org data** CSVs (Entra/HRIS export with user → organisation/department mapping) into a flat Delta table consumed by the **AI-in-One Dashboard** and **AI Business Value Dashboard** Fabric variants.\n",
+    "\n",
+    "**Inputs**: CSV(s) landed in `Files/org_raw/` of this Lakehouse. Accepted PersonId column variants: `User Principal Name`, `userPrincipalName`, `UserPrincipalName`, `UPN`, `PersonId`. The `Department` column (any case/spacing variant) is renamed to `Organization`. The `jobTitle` column is renamed to `JobTitle` for ABV-side calc-column compatibility.\n",
+    "\n",
+    "**Output**: Lakehouse Delta table `dbo.copilot_org_data`. Delta tables disallow spaces / `,;{}()\\n\\t=` in column names, so the loader sanitises all column names to underscore-safe form after canonicalisation.\n",
+    "\n",
+    "**Schedule**: run on the same cadence as your HRIS/Entra export (typically weekly).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RAW_PATH     = 'Files/org_raw/*.csv'      # raw HRIS/Entra org-data CSVs\n",
+    "OUTPUT_TABLE = 'copilot_org_data'         # Delta table consumed by the PBIT\n",
+    "WRITE_MODE   = 'overwrite'                # 'overwrite' for full snapshots"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Read raw CSVs and trim column names\n",
+    "Trimming first matches the existing M-query behaviour — exports sometimes contain leading/trailing spaces in headers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import re\n",
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "raw = (spark.read\n",
+    "    .option('header', 'true')\n",
+    "    .option('multiline', 'true')\n",
+    "    .option('escape', '\"')\n",
+    "    .csv(RAW_PATH))\n",
+    "\n",
+    "# Trim column names (matches M-query Table.TransformColumnNames step)\n",
+    "df = raw.toDF(*[c.strip() for c in raw.columns])\n",
+    "\n",
+    "print(f'Raw rows: {df.count():,}')\n",
+    "print('Detected columns:', df.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Detect column variants and canonicalise\n",
+    "PersonId and Department detection use a normalisation function (lowercase, strip punctuation/spaces) — same approach as the existing M-query."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def normalize(s: str) -> str:\n",
+    "    return re.sub(r'[\\s_\\-.\\(\\)\\[\\]]', '', s).lower()\n",
+    "\n",
+    "person_id_targets = {'userprincipalname', 'upn', 'personid'}\n",
+    "department_targets = {'department'}\n",
+    "job_title_targets  = {'jobtitle'}\n",
+    "\n",
+    "col_person_id  = next((c for c in df.columns if normalize(c) in person_id_targets), None)\n",
+    "col_department = next((c for c in df.columns if normalize(c) in department_targets), None)\n",
+    "col_job_title  = next((c for c in df.columns if normalize(c) in job_title_targets and c != 'JobTitle'), None)\n",
+    "\n",
+    "print(f'PersonId column detected:    {col_person_id}')\n",
+    "print(f'Department column detected:  {col_department}')\n",
+    "print(f'jobTitle column detected:    {col_job_title}')\n",
+    "\n",
+    "if col_person_id is not None and col_person_id != 'PersonId':\n",
+    "    df = df.withColumnRenamed(col_person_id, 'PersonId')\n",
+    "\n",
+    "if col_department is not None and col_department != 'Organization':\n",
+    "    df = df.withColumnRenamed(col_department, 'Organization')\n",
+    "\n",
+    "if col_job_title is not None:\n",
+    "    df = df.withColumnRenamed(col_job_title, 'JobTitle')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Add `PersonId_Normalized` and `TotalEmployees`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if 'PersonId' in df.columns:\n",
+    "    df = df.withColumn(\n",
+    "        'PersonId_Normalized',\n",
+    "        F.when(F.col('PersonId').isNull(), None)\n",
+    "         .otherwise(F.lower(F.trim(F.col('PersonId').cast('string'))))\n",
+    "    )\n",
+    "\n",
+    "if 'TotalEmployees' not in df.columns:\n",
+    "    total = df.count()\n",
+    "    df = df.withColumn('TotalEmployees', F.lit(str(total)))\n",
+    "\n",
+    "print(f'Final rows: {df.count():,}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Sanitize column names for Delta\n",
+    "Delta rejects ` ,;{}()\\n\\t=` in column names — replace each invalid character with `_`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_INVALID = re.compile(r'[ ,;{}()\\n\\t=]')\n",
+    "\n",
+    "def sanitize(name: str) -> str:\n",
+    "    return _INVALID.sub('_', name)\n",
+    "\n",
+    "df = df.toDF(*[sanitize(c) for c in df.columns])\n",
+    "print('Sanitized columns:', df.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Write to Lakehouse Delta table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "(df.write\n",
+    "    .format('delta')\n",
+    "    .mode(WRITE_MODE)\n",
+    "    .option('overwriteSchema', 'true')\n",
+    "    .saveAsTable(OUTPUT_TABLE))\n",
+    "\n",
+    "print(f'Rows written to {OUTPUT_TABLE}: {spark.table(OUTPUT_TABLE).count():,}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Verify\n",
+    "Spot-check `PersonId_Normalized` is populated and `Organization` looks like real department names."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tbl = spark.table(OUTPUT_TABLE)\n",
+    "cols_to_show = [c for c in ['PersonId', 'PersonId_Normalized', 'Organization', 'JobTitle'] if c in tbl.columns]\n",
+    "tbl.select(*cols_to_show).show(10, truncate=False)\n",
+    "\n",
+    "if 'Organization' in tbl.columns:\n",
+    "    tbl.groupBy('Organization').count().orderBy(F.desc('count')).show(20, truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "**Connect the PBIT**: this table is consumed by the `Chat + Agent Org Data` query in the AI-in-One and AI Business Value dashboards. Once this notebook has run, you can leave the `Org Data File` parameter blank — refresh will source from `dbo.copilot_org_data` directly via the Fabric SQL endpoint."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Synapse PySpark",
+   "language": "Python",
+   "name": "synapse_pyspark"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Builds on the audit-log-only Fabric flow by routing **licensed users** and **org data** through the lakehouse too, so the only file-path parameter remaining is `Agent 365` (manual until the Graph API loader lands). Also fixes a long-standing semantic gap in the `Inactive Licensed Users` measure.

### Notebooks (new)
- `Copilot_Licensed_Users_Loader.ipynb` — reads CSVs from `Files/licensed_raw/`, detects UPN / Has-license column-name variants, derives `UPN_Normalized`, dedupes, sanitises Delta-disallowed characters, writes `dbo.copilot_licensed_users`.
- `Copilot_Org_Data_Loader.ipynb` — reads CSVs from `Files/org_raw/`, detects PersonId / Department / jobTitle variants, derives `PersonId_Normalized` + `TotalEmployees`, sanitises column names, writes `dbo.copilot_org_data`.

### PBIT changes
- `Copilot Licensed` and `Chat + Agent Org Data` tables now source from the lakehouse via `Sql.Database` thin pass-through M-queries.
- Audit log merge step renames `Has_license` → `Has license` post-expand so the existing `License Status` calc col + downstream measures keep working unchanged.
- `sourceColumn` references on `User_Principal_Name` / `Has_license` / `Report_Refresh_Date` updated to match sanitised lakehouse columns.
- `Copilot Licensed Users` and `Org Data File` parameters made optional with blank defaults (vestigial — same pattern as `Copilot Interactions File` from the previous PR).

### Filter dynamics fix
- Previous design left `Total Licensed Users` static while `NoOfActiveChatUsers (Licensed)` responded to filters, so the `Inactive Licensed Users` subtraction was misleading once any date or org slicer was applied.
- Added a direct `Copilot Licensed[UPN_Normalized]` → `Chat + Agent Org Data[PersonId_Normalized]` relationship so org filters reach licensed users even when they have no audit activity (truly inactive licensees).

### Docs
- `Fabric/README.md` updated: new architecture diagram, three-folder raw-CSV setup, three-notebook run flow, parameter table reflecting blank-by-default, troubleshooting entries for new failure modes (key-not-match on wrong lakehouse, all-Unlicensed, Inactive=0).

## Test plan

- [ ] Land sample CSVs in `Files/audit_raw/`, `Files/licensed_raw/`, `Files/org_raw/`
- [ ] Run all three notebooks; confirm three Delta tables populate (verify cells show non-zero rows + sample values)
- [ ] Open new PBIT in Power BI Desktop; supply only `Fabric SQL Endpoint` + `Lakehouse Database`; leave the three file-path params blank
- [ ] **Apply changes** completes; all three lakehouse tables load without "key didn't match" / duplicate-column / Has-license-empty errors
- [ ] Adoption & Reach + Habit Formation pages render visuals end-to-end
- [ ] Date slicer narrows: `Total Licensed Users` stays at full population, `Inactive Licensed Users` grows
- [ ] Org slicer applied: `Total Licensed Users` scopes to that org, `Inactive Licensed Users` > 0 (not artificially zeroed)