### PR TITLE
Add Get-EntraOrgData + Agents365Registry scripts (interactive + AppReg)

### DIFF
--- a/scripts/Get-Agents365Registry.ps1
+++ b/scripts/Get-Agents365Registry.ps1
@@ -1,0 +1,130 @@
+#############################################################
+# *** EXPERIMENTAL ***
+#
+# Script to extract the Agent 365 Registry (Copilot agents catalog) from
+# Microsoft Graph and export to CSV. Output is a flat CSV with one row per
+# registered agent / package, suitable as the "Agent 365" input to the
+# AI-in-One / AI Business Value PBIP dashboards.
+#
+# *** STATUS: NOT YET VALIDATED ***
+# The Microsoft Graph endpoint for the Agent 365 admin registry is in flux
+# and the defaults below have not been confirmed against a live tenant with
+# Agent 365 licensing. Initial testing returned HTTP 403 ("Customer must be
+# licensed for Agent 365") even in tenants that DO have Agent 365 - which
+# strongly suggests the endpoint or scope below is wrong.
+#
+# To find the correct values for now:
+#   1. Open the M365 admin centre at admin.cloud.microsoft/agents/all
+#   2. Press F12 -> Network tab -> reload the page
+#   3. Inspect the requests that return the agent list - that's the real
+#      endpoint and scope you need
+#   4. Override -Endpoint and -GraphScope on the command line
+#
+# Until the defaults are verified, treat output of this script as best-effort.
+# Run interactively as a tenant admin (or any user with the required scope
+# delegated). For unattended runs, adapt the auth pattern from
+# /appreg/CreateAuditLogQuery-AppReg.ps1.
+#
+# CSV schema is dynamic - whatever fields the API returns become columns.
+# This keeps the script forward-compatible if the API adds new fields.
+#############################################################
+
+param (
+    [string]$OutputCsv  = ".\Agents365Registry.csv",
+    [string]$Endpoint   = "https://graph.microsoft.com/beta/copilot/admin/catalog/packages",
+    [string]$GraphScope = "CopilotPackages.Read.All"
+)
+
+#############################################################
+# Dependencies
+#############################################################
+
+foreach ($mod in 'Microsoft.Graph.Authentication') {
+    if (-not (Get-Module -ListAvailable -Name $mod)) {
+        try {
+            Write-Host "Installing module: $mod..."
+            Install-Module -Name $mod -Force -AllowClobber -Scope CurrentUser
+        }
+        catch {
+            Write-Host "Failed to install module '$mod': $_"
+            exit 1
+        }
+    }
+}
+
+#############################################################
+# Functions
+#############################################################
+
+function ConnectToGraph {
+    try {
+        Connect-MgGraph -Scopes $GraphScope -NoWelcome
+        Write-Host "Connected to Microsoft Graph."
+    }
+    catch {
+        Write-Host "Failed to connect to Microsoft Graph: $_"
+        exit 1
+    }
+}
+
+function ExportAgents365Registry {
+    param (
+        [string]$OutputCsvPath
+    )
+    try {
+        $OutputCsvPath = Join-Path -Path (Get-Location) -ChildPath $OutputCsvPath
+
+        $writer        = [System.IO.StreamWriter]::new($OutputCsvPath, $false, [System.Text.Encoding]::UTF8)
+        $rowCount      = 0
+        $headerWritten = $false
+        $headerKeys    = @()
+
+        # Page through the catalog
+        $uri = "$Endpoint`?`$top=999"
+        do {
+            $response = Invoke-MgGraphRequest -Method GET -Uri $uri
+
+            foreach ($item in $response.value) {
+                # Header line - dynamic schema based on first item's keys
+                if (-not $headerWritten) {
+                    $headerKeys  = @($item.Keys)
+                    $writer.WriteLine(($headerKeys | ForEach-Object { '"{0}"' -f ($_ -replace '"','""') }) -join ',')
+                    $headerWritten = $true
+                }
+
+                # Row - one value per known key (in same order)
+                $values = foreach ($k in $headerKeys) {
+                    $v = $item[$k]
+                    if ($null -eq $v)            { '""' }
+                    elseif ($v -is [string])     { '"{0}"' -f ($v -replace '"','""') }
+                    elseif ($v -is [bool])       { $v.ToString() }
+                    elseif ($v -is [DateTime])   { '"{0:O}"' -f $v }
+                    else {
+                        $json = $v | ConvertTo-Json -Compress -Depth 10
+                        '"{0}"' -f ($json -replace '"','""')
+                    }
+                }
+                $writer.WriteLine($values -join ',')
+                $rowCount++
+            }
+
+            $writer.Flush()
+            Write-Host "Processed $rowCount agents..." -ForegroundColor Green
+            $uri = $response.'@odata.nextLink'
+        } while ($uri)
+
+        $writer.Dispose()
+        Write-Host "Exported $rowCount agents to: $OutputCsvPath" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "Failed to export Agents 365 registry: $_" -ForegroundColor Red
+        exit 1
+    }
+}
+
+#############################################################
+# Main
+#############################################################
+
+ConnectToGraph
+ExportAgents365Registry -OutputCsvPath $OutputCsv

--- a/scripts/Get-EntraOrgData.ps1
+++ b/scripts/Get-EntraOrgData.ps1
@@ -1,0 +1,112 @@
+#############################################################
+# Script to extract organisational data (manager, department, etc) for all
+# users from Microsoft Entra ID via Microsoft Graph and export to CSV.
+#
+# Output is a flat CSV with one row per user, suitable as the "Org Data"
+# input to the AI-in-One / AI Business Value PBIP dashboards.
+#
+# Run this interactively as a tenant admin (or any user with User.Read.All
+# delegated permission). For unattended runs, adapt the auth pattern from
+# /appreg/CreateAuditLogQuery-AppReg.ps1.
+#
+# Output schema (CSV columns):
+#   userPrincipalName  - join key (auto-renames to PersonId in PBIP Power Query)
+#   displayName
+#   department
+#   jobTitle
+#   companyName
+#   officeLocation
+#   city
+#   country
+#   accountEnabled     - TRUE/FALSE
+#   managerUPN         - UPN of direct manager (blank if no manager)
+#############################################################
+
+param (
+    [string]$OutputCsv = ".\EntraOrgData.csv"
+)
+
+#############################################################
+# Dependencies
+#############################################################
+
+foreach ($mod in 'Microsoft.Graph.Authentication') {
+    if (-not (Get-Module -ListAvailable -Name $mod)) {
+        try {
+            Write-Host "Installing module: $mod..."
+            Install-Module -Name $mod -Force -AllowClobber -Scope CurrentUser
+        }
+        catch {
+            Write-Host "Failed to install module '$mod': $_"
+            exit 1
+        }
+    }
+}
+
+#############################################################
+# Functions
+#############################################################
+
+function ConnectToGraph {
+    try {
+        Connect-MgGraph -Scopes "User.Read.All" -NoWelcome
+        Write-Host "Connected to Microsoft Graph."
+    }
+    catch {
+        Write-Host "Failed to connect to Microsoft Graph: $_"
+        exit 1
+    }
+}
+
+function ExportEntraOrgData {
+    param (
+        [string]$OutputCsvPath
+    )
+    try {
+        $OutputCsvPath = Join-Path -Path (Get-Location) -ChildPath $OutputCsvPath
+
+        $writer = [System.IO.StreamWriter]::new($OutputCsvPath, $false, [System.Text.Encoding]::UTF8)
+        $cols = 'userPrincipalName','displayName','department','jobTitle','companyName','officeLocation','city','country','accountEnabled','managerUPN'
+        $writer.WriteLine(($cols | ForEach-Object { '"{0}"' -f $_ }) -join ',')
+
+        # Page through users with manager expanded
+        $selectFields = 'userPrincipalName,displayName,department,jobTitle,companyName,officeLocation,city,country,accountEnabled'
+        $expandManager = 'manager($select=userPrincipalName)'
+        $uri = "https://graph.microsoft.com/v1.0/users?`$select=$selectFields&`$expand=$expandManager&`$top=999"
+        $rowCount = 0
+
+        do {
+            $response = Invoke-MgGraphRequest -Method GET -Uri $uri
+            foreach ($u in $response.value) {
+                $managerUpn = ''
+                if ($u.manager) { $managerUpn = $u.manager.userPrincipalName }
+                $values = @(
+                    $u.userPrincipalName, $u.displayName, $u.department, $u.jobTitle,
+                    $u.companyName, $u.officeLocation, $u.city, $u.country,
+                    [string]$u.accountEnabled, $managerUpn
+                ) | ForEach-Object {
+                    if ($null -eq $_) { '""' } else { '"{0}"' -f ($_ -replace '"','""') }
+                }
+                $writer.WriteLine($values -join ',')
+                $rowCount++
+            }
+            $writer.Flush()
+            Write-Host "Processed $rowCount users..." -ForegroundColor Green
+            $uri = $response.'@odata.nextLink'
+        } while ($uri)
+
+        $writer.Dispose()
+        Write-Host "Exported $rowCount users to: $OutputCsvPath" -ForegroundColor Green
+    }
+    catch {
+        Write-Host "Failed to export Entra org data: $_" -ForegroundColor Red
+        exit 1
+    }
+}
+
+#############################################################
+# Main
+#############################################################
+
+ConnectToGraph
+ExportEntraOrgData -OutputCsvPath $OutputCsv

--- a/scripts/automation/appreg/Get-EntraOrgData-AppReg.ps1
+++ b/scripts/automation/appreg/Get-EntraOrgData-AppReg.ps1
@@ -1,0 +1,199 @@
+#############################################################
+# Script to extract organisational data (manager, department, etc) for all
+# users from Microsoft Entra ID via Microsoft Graph and upload the CSV to
+# a SharePoint document library. Designed to run unattended in Azure
+# Automation alongside the Copilot interactions runbooks.
+#
+# Supports managed identity (default), app registration + secret, or
+# app registration + certificate.
+#
+# Permissions needed (Application):
+# - For Microsoft Graph: User.Read.All, Sites.Selected
+#
+# Output schema (CSV columns):
+#   userPrincipalName  - join key (auto-renames to PersonId in PBIP Power Query)
+#   displayName
+#   department
+#   jobTitle
+#   companyName
+#   officeLocation
+#   city
+#   country
+#   accountEnabled
+#   managerUPN
+#############################################################
+
+#############################################################
+# Parameters
+#############################################################
+
+param (
+    [string]$DriveId = "",  # Graph Drive ID of the target SharePoint document library
+
+    # App registration auth (optional - leave all blank to use managed identity)
+    [string]$TenantId = "",
+    [string]$ClientId = "",
+    [string]$ClientSecret = "",
+    [string]$CertificateThumbprint = ""
+)
+
+#############################################################
+# Auth Mode Validation
+#############################################################
+
+$useSecret      = -not [string]::IsNullOrWhiteSpace($ClientSecret)
+$useCert        = -not [string]::IsNullOrWhiteSpace($CertificateThumbprint)
+$hasTenantId    = -not [string]::IsNullOrWhiteSpace($TenantId)
+$hasClientId    = -not [string]::IsNullOrWhiteSpace($ClientId)
+$hasAppRegParam = $useSecret -or $useCert -or $hasTenantId -or $hasClientId
+
+if ($hasAppRegParam) {
+    if ($useSecret -and $useCert) {
+        Write-Error "Provide either -ClientSecret OR -CertificateThumbprint, not both."
+        exit 1
+    }
+    if (-not $hasTenantId) {
+        Write-Error "-TenantId is required when using app registration authentication."
+        exit 1
+    }
+    if (-not $hasClientId) {
+        Write-Error "-ClientId is required when using app registration authentication."
+        exit 1
+    }
+    if (-not $useSecret -and -not $useCert) {
+        Write-Error "Provide either -ClientSecret or -CertificateThumbprint when using app registration authentication."
+        exit 1
+    }
+    if ($useSecret) { $authMode = "AppSecret" } else { $authMode = "AppCert" }
+} else {
+    $authMode = "ManagedIdentity"
+}
+
+if ([string]::IsNullOrWhiteSpace($DriveId)) {
+    Write-Error "-DriveId is required (target SharePoint document library)."
+    exit 1
+}
+
+Write-Output "Auth mode: $authMode"
+
+#############################################################
+# Dependencies
+#############################################################
+
+foreach ($moduleName in @('Microsoft.Graph.Authentication')) {
+    if (-not (Get-Module -ListAvailable -Name $moduleName)) {
+        try {
+            Write-Output "Installing module: $moduleName..."
+            Install-Module -Name $moduleName -Force -AllowClobber -Scope CurrentUser
+        }
+        catch {
+            Write-Error "Failed to install module '$moduleName': $_"
+            exit 1
+        }
+    }
+    Write-Output "Importing module: $moduleName..."
+    Import-Module -Name $moduleName -Force
+}
+
+#############################################################
+# Functions
+#############################################################
+
+function ConnectToGraph {
+    try {
+        switch ($authMode) {
+            "ManagedIdentity" {
+                Connect-MgGraph -Identity -NoWelcome
+            }
+            "AppSecret" {
+                $secureSecret = ConvertTo-SecureString $ClientSecret -AsPlainText -Force
+                $credential   = New-Object System.Management.Automation.PSCredential($ClientId, $secureSecret)
+                Connect-MgGraph -ClientSecretCredential $credential -TenantId $TenantId -NoWelcome
+            }
+            "AppCert" {
+                Connect-MgGraph -ClientId $ClientId -TenantId $TenantId -CertificateThumbprint $CertificateThumbprint -NoWelcome
+            }
+        }
+        Write-Output "Connected to Microsoft Graph."
+    }
+    catch {
+        Write-Error "Failed to connect to Microsoft Graph: $_"
+        exit 1
+    }
+}
+
+# Build the full CSV in a memory stream, then upload to SharePoint in one go.
+# Org-data exports are small enough (under a few MB even for large tenants)
+# that chunked streaming is overkill; a single PUT to a small-file upload URL
+# is simpler and reliable.
+function ExportEntraOrgDataAndUpload {
+    param (
+        [Parameter(Mandatory)]
+        [string]$DriveId,
+
+        [Parameter(Mandatory)]
+        [string]$FileName
+    )
+
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+    $cols = 'userPrincipalName','displayName','department','jobTitle','companyName','officeLocation','city','country','accountEnabled','managerUPN'
+
+    $sb = [System.Text.StringBuilder]::new()
+    [void]$sb.AppendLine(($cols | ForEach-Object { '"{0}"' -f $_ }) -join ',')
+
+    $selectFields  = 'userPrincipalName,displayName,department,jobTitle,companyName,officeLocation,city,country,accountEnabled'
+    $expandManager = 'manager($select=userPrincipalName)'
+    $uri = "https://graph.microsoft.com/v1.0/users?`$select=$selectFields&`$expand=$expandManager&`$top=999"
+    $rowCount = 0
+
+    try {
+        do {
+            $response = Invoke-MgGraphRequest -Method GET -Uri $uri
+            foreach ($u in $response.value) {
+                $managerUpn = ''
+                if ($u.manager) { $managerUpn = $u.manager.userPrincipalName }
+                $values = @(
+                    $u.userPrincipalName, $u.displayName, $u.department, $u.jobTitle,
+                    $u.companyName, $u.officeLocation, $u.city, $u.country,
+                    [string]$u.accountEnabled, $managerUpn
+                ) | ForEach-Object {
+                    if ($null -eq $_) { '""' } else { '"{0}"' -f ($_ -replace '"','""') }
+                }
+                [void]$sb.AppendLine($values -join ',')
+                $rowCount++
+            }
+            Write-Output "Processed $rowCount users..."
+            $uri = $response.'@odata.nextLink'
+        } while ($uri)
+    }
+    catch {
+        Write-Error "Failed to fetch users from Graph: $_"
+        exit 1
+    }
+
+    $bytes = [System.Text.Encoding]::UTF8.GetBytes($sb.ToString())
+    Write-Output ("CSV built in memory: {0} rows / {1} KB. Uploading..." -f $rowCount, [Math]::Round($bytes.Length / 1KB, 1))
+
+    # Use simple PUT (single chunk) since the file is small.
+    try {
+        $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/$($FileName):/content"
+        Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $bytes -ContentType 'text/csv' | Out-Null
+        Write-Output "Successfully uploaded $rowCount users to $FileName"
+    }
+    catch {
+        Write-Error "Failed to upload CSV to SharePoint: $_"
+        exit 1
+    }
+}
+
+#############################################################
+# Main Script Execution
+#############################################################
+
+ConnectToGraph
+
+$TargetFileName = "EntraOrgData-$(Get-Date -Format 'yyyyMMddHHmmss').csv"
+ExportEntraOrgDataAndUpload -DriveId $DriveId -FileName $TargetFileName
+
+Write-Output "Entra org data report generated at: $TargetFileName"

--- a/scripts/automation/appreg/README.md
+++ b/scripts/automation/appreg/README.md
@@ -323,16 +323,79 @@ to the root of the document library.
 
 ---
 
+## Script 4 — Get-EntraOrgData-AppReg.ps1
+
+**Optional companion runbook.** Pulls organisational data (manager, department, location, etc.) for all users from Microsoft Entra ID and uploads the CSV to the same SharePoint document library used by the audit-log runbooks. Output feeds the **Org Data** parameter of the dashboard PBIP.
+
+This is the unattended counterpart to the interactive `Get-EntraOrgData.ps1` in the parent `/scripts/` folder.
+
+### What it does
+
+1. Authenticates to Microsoft Graph using the configured auth mode.
+2. Pages through `GET /v1.0/users` with `$select` and `$expand=manager`.
+3. Builds the CSV in memory (org-data exports are small — under a few MB even for large tenants).
+4. Uploads the CSV to the document library via a single PUT (no chunked upload session needed).
+
+### Required permissions
+
+| Permission | Type | Purpose |
+|---|---|---|
+| `User.Read.All` | Application | Read user profile + manager data |
+| `Sites.Selected` | Application | Write the CSV to the document library |
+
+> ⚠️ `ProvisionPreReqs.ps1` does **not** yet declare `User.Read.All` on the app registration. If you intend to use this runbook, add the permission manually in the Azure portal (App registration → API permissions → Microsoft Graph → Application permissions → `User.Read.All`) and grant admin consent. Re-running `ProvisionPreReqs.ps1` after editing the script to include the permission ID `df021288-bdef-4463-88db-98f22de89214` would also work.
+
+### Authentication modes
+
+The same three modes as the interactions runbooks (Managed Identity, App secret, Certificate). Substitute `Get-EntraOrgData-AppReg.ps1` in the examples above.
+
+```powershell
+# Managed Identity
+.\Get-EntraOrgData-AppReg.ps1 -DriveId "<drive-id>"
+
+# App secret
+.\Get-EntraOrgData-AppReg.ps1 `
+    -DriveId      "<drive-id>" `
+    -TenantId     "<tenant-id>" `
+    -ClientId     "<app-client-id>" `
+    -ClientSecret "<client-secret>"
+```
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `DriveId` | string | **Yes** | — | Graph Drive ID of the document library (same one used by Runbook 2) |
+| `TenantId` | string | No* | — | Entra tenant ID — required when using app registration auth |
+| `ClientId` | string | No* | — | App registration client ID — required when using app registration auth |
+| `ClientSecret` | string | No* | — | Client secret (mutually exclusive with `CertificateThumbprint`) |
+| `CertificateThumbprint` | string | No* | — | Certificate thumbprint (mutually exclusive with `ClientSecret`) |
+
+\* Required together when using app registration authentication.
+
+### Output
+
+CSV file named:
+
+```
+EntraOrgData-{yyyyMMddHHmmss}.csv
+```
+
+uploaded to the root of the document library.
+
+---
+
 ## Permissions summary
 
-| Permission | `ProvisionPreReqs.ps1` | Runbook 1 | Runbook 2 |
-|---|:---:|:---:|:---:|
-| `Application.ReadWrite.All` (delegated) | Required to run | — | — |
-| `AppRoleAssignment.ReadWrite.All` (delegated) | Required to run | — | — |
-| `Sites.FullControl.All` (delegated) | Required to run | — | — |
-| `AuditLog.Read.All` (application) | Granted to app | — | ✓ |
-| `AuditLogsQuery.Read.All` (application) | Granted to app | ✓ | — |
-| `Sites.Selected` (application) | Granted to app | ✓ | ✓ |
+| Permission | `ProvisionPreReqs.ps1` | Runbook 1 | Runbook 2 | Org Data Runbook |
+|---|:---:|:---:|:---:|:---:|
+| `Application.ReadWrite.All` (delegated) | Required to run | — | — | — |
+| `AppRoleAssignment.ReadWrite.All` (delegated) | Required to run | — | — | — |
+| `Sites.FullControl.All` (delegated) | Required to run | — | — | — |
+| `AuditLog.Read.All` (application) | Granted to app | — | ✓ | — |
+| `AuditLogsQuery.Read.All` (application) | Granted to app | ✓ | — | — |
+| `User.Read.All` (application) | _Add manually_ — see Script 4 note | — | — | ✓ |
+| `Sites.Selected` (application) | Granted to app | ✓ | ✓ | ✓ |
 
 ---
 

--- a/scripts/readme.md
+++ b/scripts/readme.md
@@ -22,6 +22,7 @@ This folder contains PowerShell scripts to retrieve and export Microsoft Copilot
 | App registration / signed-in account is consented to `AuditLogsQuery.Read.All` | Entra Admin Centre → Identity → Applications → Enterprise applications → find your app → Permissions |
 | Optional granular workload scopes (`AuditLogsQuery-*.Read.All`) for least-privilege deployments | Same place — only needed if you want narrower-than-tenant-wide consent |
 | `Reports.Read.All` for `get-copilot-users.ps1` | unchanged from before |
+| `User.Read.All` for `Get-EntraOrgData.ps1` | Granted via the same admin-consent flow |
 
 **Quick check** — after `Connect-MgGraph`, run:
 ```powershell
@@ -129,6 +130,68 @@ You should see `AuditLogsQuery.Read.All` listed. If you only see `AuditLog.Read.
 
 **Output**:
 - CSV file with user information and interaction statistics
+
+---
+
+### 4. `Get-EntraOrgData.ps1`
+
+**Purpose**: Extracts organisational data (manager, department, location, etc.) for all users from Microsoft Entra ID. Output feeds the **Org Data** parameter of the dashboard PBIP.
+
+**Usage**:
+```powershell
+# With defaults (writes to ./EntraOrgData.csv)
+./Get-EntraOrgData.ps1
+
+# Custom output path
+./Get-EntraOrgData.ps1 -OutputCsv ".\MyOrgData.csv"
+```
+
+**Required scope**: `User.Read.All` (delegated). Tenant admin consent typically required.
+
+**What it does**:
+- Connects to Microsoft Graph interactively
+- Pages through `/v1.0/users` with `$select` and `$expand=manager`
+- Writes a CSV with one row per user
+
+**Output schema** (CSV columns):
+
+| Column | Notes |
+|---|---|
+| `userPrincipalName` | Join key — auto-renames to `PersonId` in PBIP Power Query |
+| `displayName` | |
+| `department` | |
+| `jobTitle` | |
+| `companyName` | |
+| `officeLocation` | |
+| `city` | |
+| `country` | |
+| `accountEnabled` | TRUE/FALSE |
+| `managerUPN` | UPN of direct manager (blank if none) |
+
+For unattended runs (Azure Automation), use the AppReg variant: [`automation/appreg/Get-EntraOrgData-AppReg.ps1`](automation/appreg/Get-EntraOrgData-AppReg.ps1).
+
+---
+
+### 5. `Get-Agents365Registry.ps1` ⚠️ **EXPERIMENTAL**
+
+**Purpose**: Extracts the Agent 365 Registry (Copilot agents catalog) from Microsoft Graph. Output feeds the **Agent 365** parameter of the dashboard PBIP.
+
+> ⚠️ **Status: not yet validated.** The Microsoft Graph endpoint for the Agent 365 admin registry is in flux and the script's defaults have not been confirmed against a live tenant. Initial testing returned HTTP 403 ("Customer must be licensed for Agent 365") even on tenants that DO have Agent 365 — strongly suggesting the default endpoint or scope is wrong.
+>
+> **Workaround until verified**: discover the real endpoint by opening `admin.cloud.microsoft/agents/all`, pressing F12 → Network tab, reloading, and inspecting the request that returns the agent list. Then override `-Endpoint` and `-GraphScope` on the command line.
+
+**Usage**:
+```powershell
+# With defaults (likely fails with 403 - see status note above)
+./Get-Agents365Registry.ps1
+
+# With overridden endpoint / scope
+./Get-Agents365Registry.ps1 `
+    -Endpoint   "https://graph.microsoft.com/beta/<actual-path>" `
+    -GraphScope "<actual-scope>"
+```
+
+**Output**: CSV with one row per agent. Schema is **dynamic** — whatever fields the API returns become columns. This keeps the script forward-compatible if Microsoft adds new fields.
 
 ---
 


### PR DESCRIPTION
- New: scripts/Get-EntraOrgData.ps1 - pulls org structure (manager, dept, location, etc.) from Entra ID for the Org Data PBIP parameter
- New: scripts/Get-Agents365Registry.ps1 - pulls Copilot agents catalog for the Agent 365 PBIP parameter. EXPERIMENTAL: endpoint/scope defaults not yet validated against a live tenant; expect to override on cmdline.
- New: scripts/automation/appreg/Get-EntraOrgData-AppReg.ps1 - unattended runbook variant (managed identity / app secret / cert) that uploads CSV to a SharePoint document library.
- Updated: scripts/readme.md and appreg/README.md to document the new scripts, their permissions (User.Read.All), and the experimental status.

Note: .ps1 files force-added (-f) because .gitignore excludes *.ps1 and scripts/automation/appreg/ to keep client secrets out of the repo.