### PR TITLE
Fix SharePoint upload for files over 4 MB (chunked upload session)

### DIFF
--- a/1. Manual/README.md
+++ b/1. Manual/README.md
@@ -24,7 +24,7 @@ Best for ad-hoc analysis, one-off exports, or single-user dashboards.
 
 Two options:
 
-**(A) Run the scripts** — kept in [`../SharePoint/Single File/scripts/interactive/`](../SharePoint/Single%20File/scripts/interactive/) since they're the same scripts. Run `create-query.ps1` then `get-copilot-interactions.ps1` — produces a CSV in your current directory.
+**(A) Run the scripts** — kept in [`../2. SharePoint/Single File/scripts/interactive/`](../2.%20SharePoint/Single%20File/scripts/interactive/) since they're the same scripts. Run `create-query.ps1` then `get-copilot-interactions.ps1` — produces a CSV in your current directory.
 
 **(B) Manual export from Purview UI**:
 - Go to https://purview.microsoft.com → Solutions → **Audit**

--- a/2. SharePoint/Folder/README.md
+++ b/2. SharePoint/Folder/README.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **This is the advanced SharePoint path.** Most customers should use [`../Single File/`](../Single%20File/) instead — it's simpler, has none of the privacy-firewall fragilities documented below, and works for ~80% of real deployments.
 >
-> Use this Folder path **only if** you need >30 days of accumulated audit history *and* you don't have Fabric capacity. If you have Fabric, use [`../../Fabric/`](../../Fabric/) — it solves the same problem more robustly.
+> Use this Folder path **only if** you need >30 days of accumulated audit history *and* you don't have Fabric capacity. If you have Fabric, use [`../../3. Fabric/`](../../3.%20Fabric/) — it solves the same problem more robustly.
 
 Use this template when your audit-log CSVs land in a **SharePoint folder** (typically as scheduled drops accumulating over time) and you want Power BI Service to auto-union and refresh them.
 
@@ -77,7 +77,7 @@ Formula.Firewall: Query references other queries or steps...
 - Set customer expectations up front: dashboard history starts from the date you began running the export script
 - Run the script weekly (minimum) so the SharePoint folder accumulates beyond 180 days over time
 - **Never delete old CSVs** — they're your only history record beyond the rolling 180-day Graph window
-- For 2-year+ history needs, switch to the [`Fabric/`](../Fabric/) deployment path with managed Lakehouse retention
+- For 2-year+ history needs, switch to the [`3. Fabric/`](../../3.%20Fabric/) deployment path with managed Lakehouse retention
 
 ### 4. Don't overlap your script's date windows
 
@@ -152,7 +152,7 @@ This is what `scripts/get-copilot-interactions.ps1` produces. If your export use
 | Inflated counts, users with 5-7× expected activity | Date windows in your script runs are overlapping | See Pitfall #4 above. Use non-overlapping windows |
 | Desktop refresh works, Service refresh fails with `Access denied` | Per-URL credentials missing in Service | See Pitfall #5 above. Sign in to every SharePoint URL in dataset Settings |
 | "Can't see data before February" / "Where's my 2025 history?" | Microsoft Graph 180-day audit log API limit | See Pitfall #3 above. Don't delete old CSVs; for >180 days history use Fabric path |
-| Refresh times out (2-hour limit on shared) or hits 1 GB memory cap | Volume too large for in-dataset JSON parsing | Switch to the [`Fabric/`](../Fabric/) deployment path — moves parsing upstream, eliminates the limits |
+| Refresh times out (2-hour limit on shared) or hits 1 GB memory cap | Volume too large for in-dataset JSON parsing | Switch to the [`3. Fabric/`](../../3.%20Fabric/) deployment path — moves parsing upstream, eliminates the limits |
 
 ## When this approach isn't right
 
@@ -161,7 +161,7 @@ If you're hitting the same pitfalls repeatedly, or the data volume keeps trippin
 | Alternative | Pattern | Best for |
 |---|---|---|
 | **Single File** ([`../Single File/`](../Single%20File/)) | Script always writes to one CSV per source, overwriting. PBI reads one static URL — no folder iteration, no Privacy Firewall trips | Customers with simple needs, low volume, who don't need >180 days of history |
-| **Fabric Lakehouse** ([`../../Fabric/`](../../Fabric/)) | Script lands data in a Lakehouse Delta table; PBI queries the table directly. No SharePoint, no folder iteration | Enterprise customers with Fabric capacity, large tenants, multi-year history needs |
+| **Fabric Lakehouse** ([`../../3. Fabric/`](../../3.%20Fabric/)) | Script lands data in a Lakehouse Delta table; PBI queries the table directly. No SharePoint, no folder iteration | Enterprise customers with Fabric capacity, large tenants, multi-year history needs |
 
 ## Compared to the other paths
 

--- a/2. SharePoint/Folder/scripts/appreg/Get-EntraOrgData-SP-AppReg.ps1
+++ b/2. SharePoint/Folder/scripts/appreg/Get-EntraOrgData-SP-AppReg.ps1
@@ -120,12 +120,49 @@ function UploadToSharePoint {
     $uploadPath = if ([string]::IsNullOrWhiteSpace($cleanFolder)) { $FileName } else { "$cleanFolder/$FileName" }
     $encodedSegments = $uploadPath.Split('/') | ForEach-Object { [uri]::EscapeDataString($_) }
     $encodedPath = $encodedSegments -join '/'
-    $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/content"
+
+    # Graph caps simple PUT at 4 MB. Above that → createUploadSession + chunked PUT.
+    # To exercise the chunked branch on a small test CSV, temporarily lower this to e.g. 100.
+    $simpleUploadCap = 4 * 1024 * 1024
+
     Write-Output "Uploading $($Bytes.Length) bytes to: $uploadPath"
+
+    if ($Bytes.Length -le $simpleUploadCap) {
+        $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/content"
+        try {
+            Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $Bytes -ContentType 'text/csv' | Out-Null
+            Write-Output "Upload complete (simple PUT)."
+        } catch { Write-Error "Failed to upload CSV to SharePoint: $_"; exit 1 }
+        return
+    }
+
+    $sessionUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/createUploadSession"
+    $sessionBody = @{ item = @{ '@microsoft.graph.conflictBehavior' = 'replace' } } | ConvertTo-Json
     try {
-        Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $Bytes -ContentType 'text/csv' | Out-Null
-        Write-Output "Upload complete."
-    } catch { Write-Error "Failed to upload CSV to SharePoint: $_"; exit 1 }
+        $session = Invoke-MgGraphRequest -Method POST -Uri $sessionUri -Body $sessionBody -ContentType 'application/json'
+    } catch { Write-Error "Failed to create upload session: $_"; exit 1 }
+    $uploadUrl = $session.uploadUrl
+    if (-not $uploadUrl) { Write-Error "createUploadSession returned no uploadUrl"; exit 1 }
+
+    $chunkSize = 5 * 1024 * 1024   # multiple of 320 KB required by Graph
+    $total  = $Bytes.Length
+    $offset = 0
+    while ($offset -lt $total) {
+        $end = [Math]::Min($offset + $chunkSize, $total) - 1
+        $len = $end - $offset + 1
+        $chunk = New-Object byte[] $len
+        [Array]::Copy($Bytes, $offset, $chunk, 0, $len)
+        $contentRange = "bytes $offset-$end/$total"
+        try {
+            Invoke-WebRequest -Uri $uploadUrl -Method Put `
+                -Body $chunk -ContentType 'application/octet-stream' `
+                -Headers @{ 'Content-Range' = $contentRange } `
+                -UseBasicParsing -ErrorAction Stop | Out-Null
+        } catch { Write-Error "Chunk upload failed at $contentRange : $_"; exit 1 }
+        $offset = $end + 1
+        Write-Output ("Uploaded {0:N0}/{1:N0} bytes" -f $offset, $total)
+    }
+    Write-Output "Upload complete (upload session)."
 }
 
 #############################################################

--- a/2. SharePoint/Folder/scripts/appreg/GetCopilotInteractions-SP-AppReg.ps1
+++ b/2. SharePoint/Folder/scripts/appreg/GetCopilotInteractions-SP-AppReg.ps1
@@ -193,15 +193,59 @@ function UploadToSharePoint {
     $encodedSegments = $uploadPath.Split('/') | ForEach-Object { [uri]::EscapeDataString($_) }
     $encodedPath = $encodedSegments -join '/'
 
-    $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/content"
+    # Graph caps simple PUT (root:/path:/content) at 4 MB. Larger files need an upload session
+    # with chunked PUTs and Content-Range headers. To exercise the chunked branch on a small
+    # test CSV, temporarily lower this to e.g. 100.
+    $simpleUploadCap = 4 * 1024 * 1024
+
     Write-Output "Uploading $($Bytes.Length) bytes to: $uploadPath"
 
-    try {
-        Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $Bytes -ContentType 'text/csv' | Out-Null
-        Write-Output "Upload complete."
-    } catch {
-        Write-Error "Failed to upload CSV to SharePoint: $_"; exit 1
+    if ($Bytes.Length -le $simpleUploadCap) {
+        $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/content"
+        try {
+            Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $Bytes -ContentType 'text/csv' | Out-Null
+            Write-Output "Upload complete (simple PUT)."
+        } catch {
+            Write-Error "Failed to upload CSV to SharePoint: $_"; exit 1
+        }
+        return
     }
+
+    # Large file: createUploadSession then chunked PUT with Content-Range.
+    $sessionUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/createUploadSession"
+    $sessionBody = @{ item = @{ '@microsoft.graph.conflictBehavior' = 'replace' } } | ConvertTo-Json
+    try {
+        $session = Invoke-MgGraphRequest -Method POST -Uri $sessionUri -Body $sessionBody -ContentType 'application/json'
+    } catch {
+        Write-Error "Failed to create upload session: $_"; exit 1
+    }
+    $uploadUrl = $session.uploadUrl
+    if (-not $uploadUrl) { Write-Error "createUploadSession returned no uploadUrl"; exit 1 }
+
+    # Upload session chunk size must be a multiple of 320 KB. 5 MB = 16 * 320 KB.
+    $chunkSize = 5 * 1024 * 1024
+    $total  = $Bytes.Length
+    $offset = 0
+
+    while ($offset -lt $total) {
+        $end = [Math]::Min($offset + $chunkSize, $total) - 1
+        $len = $end - $offset + 1
+        $chunk = New-Object byte[] $len
+        [Array]::Copy($Bytes, $offset, $chunk, 0, $len)
+        $contentRange = "bytes $offset-$end/$total"
+
+        try {
+            Invoke-WebRequest -Uri $uploadUrl -Method Put `
+                -Body $chunk -ContentType 'application/octet-stream' `
+                -Headers @{ 'Content-Range' = $contentRange } `
+                -UseBasicParsing -ErrorAction Stop | Out-Null
+        } catch {
+            Write-Error "Chunk upload failed at $contentRange : $_"; exit 1
+        }
+        $offset = $end + 1
+        Write-Output ("Uploaded {0:N0}/{1:N0} bytes" -f $offset, $total)
+    }
+    Write-Output "Upload complete (upload session)."
 }
 
 #############################################################

--- a/2. SharePoint/Folder/scripts/appreg/GetCopilotUsers-SP-AppReg.ps1
+++ b/2. SharePoint/Folder/scripts/appreg/GetCopilotUsers-SP-AppReg.ps1
@@ -145,12 +145,49 @@ function UploadToSharePoint {
     $uploadPath = if ([string]::IsNullOrWhiteSpace($cleanFolder)) { $FileName } else { "$cleanFolder/$FileName" }
     $encodedSegments = $uploadPath.Split('/') | ForEach-Object { [uri]::EscapeDataString($_) }
     $encodedPath = $encodedSegments -join '/'
-    $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/content"
+
+    # Graph caps simple PUT at 4 MB. Above that → createUploadSession + chunked PUT.
+    # To exercise the chunked branch on a small test CSV, temporarily lower this to e.g. 100.
+    $simpleUploadCap = 4 * 1024 * 1024
+
     Write-Output "Uploading $($Bytes.Length) bytes to: $uploadPath"
+
+    if ($Bytes.Length -le $simpleUploadCap) {
+        $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/content"
+        try {
+            Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $Bytes -ContentType 'text/csv' | Out-Null
+            Write-Output "Upload complete (simple PUT)."
+        } catch { Write-Error "Failed to upload CSV to SharePoint: $_"; exit 1 }
+        return
+    }
+
+    $sessionUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/createUploadSession"
+    $sessionBody = @{ item = @{ '@microsoft.graph.conflictBehavior' = 'replace' } } | ConvertTo-Json
     try {
-        Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $Bytes -ContentType 'text/csv' | Out-Null
-        Write-Output "Upload complete."
-    } catch { Write-Error "Failed to upload CSV to SharePoint: $_"; exit 1 }
+        $session = Invoke-MgGraphRequest -Method POST -Uri $sessionUri -Body $sessionBody -ContentType 'application/json'
+    } catch { Write-Error "Failed to create upload session: $_"; exit 1 }
+    $uploadUrl = $session.uploadUrl
+    if (-not $uploadUrl) { Write-Error "createUploadSession returned no uploadUrl"; exit 1 }
+
+    $chunkSize = 5 * 1024 * 1024   # multiple of 320 KB required by Graph
+    $total  = $Bytes.Length
+    $offset = 0
+    while ($offset -lt $total) {
+        $end = [Math]::Min($offset + $chunkSize, $total) - 1
+        $len = $end - $offset + 1
+        $chunk = New-Object byte[] $len
+        [Array]::Copy($Bytes, $offset, $chunk, 0, $len)
+        $contentRange = "bytes $offset-$end/$total"
+        try {
+            Invoke-WebRequest -Uri $uploadUrl -Method Put `
+                -Body $chunk -ContentType 'application/octet-stream' `
+                -Headers @{ 'Content-Range' = $contentRange } `
+                -UseBasicParsing -ErrorAction Stop | Out-Null
+        } catch { Write-Error "Chunk upload failed at $contentRange : $_"; exit 1 }
+        $offset = $end + 1
+        Write-Output ("Uploaded {0:N0}/{1:N0} bytes" -f $offset, $total)
+    }
+    Write-Output "Upload complete (upload session)."
 }
 
 #############################################################

--- a/2. SharePoint/README.md
+++ b/2. SharePoint/README.md
@@ -13,7 +13,7 @@ Two SharePoint patterns are available — pick the one that fits your scenario:
 Are you a customer with > 100K events/week?
 ├── No  → Single File (rolling 30 days is plenty)
 └── Yes → Do you have Fabric capacity?
-         ├── Yes → use Fabric path instead (../Fabric/), not SharePoint at all
+         ├── Yes → use Fabric path instead (../3. Fabric/), not SharePoint at all
          └── No  → Folder (180-day cap, but accept the additional fragility)
 ```
 
@@ -37,4 +37,4 @@ Are you a customer with > 100K events/week?
 
 ## When to escape SharePoint entirely
 
-If you're hitting the 1 GB / 2-hour PBI refresh caps on shared capacity, or your customer needs multi-year history, switch to [`../Fabric/`](../Fabric/). Fabric Lakehouse handles upstream parsing and gives you Direct Lake performance.
+If you're hitting the 1 GB / 2-hour PBI refresh caps on shared capacity, or your customer needs multi-year history, switch to [`../3. Fabric/`](../3.%20Fabric/). Fabric Lakehouse handles upstream parsing and gives you Direct Lake performance.

--- a/2. SharePoint/Single File/README.md
+++ b/2. SharePoint/Single File/README.md
@@ -103,6 +103,6 @@ For Azure Automation specifically, see [`scripts/azure/`](scripts/azure/) for Bi
 
 | Symptom | Move to |
 |---|---|
-| You need >30 days of historical data | [`../Folder/`](../Folder/) (advanced) or [`../../Fabric/`](../../Fabric/) |
-| Refresh hits 1 GB / 2-hour caps | [`../../Fabric/`](../../Fabric/) (Lakehouse handles parsing upstream) |
-| You don't need scheduled refresh, just a one-off CSV | [`../../Manual/`](../../Manual/) |
+| You need >30 days of historical data | [`../Folder/`](../Folder/) (advanced) or [`../../3. Fabric/`](../../3.%20Fabric/) |
+| Refresh hits 1 GB / 2-hour caps | [`../../3. Fabric/`](../../3.%20Fabric/) (Lakehouse handles parsing upstream) |
+| You don't need scheduled refresh, just a one-off CSV | [`../../1. Manual/`](../../1.%20Manual/) |

--- a/2. SharePoint/Single File/scripts/appreg/Get-EntraOrgData-SP-AppReg.ps1
+++ b/2. SharePoint/Single File/scripts/appreg/Get-EntraOrgData-SP-AppReg.ps1
@@ -120,12 +120,49 @@ function UploadToSharePoint {
     $uploadPath = if ([string]::IsNullOrWhiteSpace($cleanFolder)) { $FileName } else { "$cleanFolder/$FileName" }
     $encodedSegments = $uploadPath.Split('/') | ForEach-Object { [uri]::EscapeDataString($_) }
     $encodedPath = $encodedSegments -join '/'
-    $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/content"
+
+    # Graph caps simple PUT at 4 MB. Above that → createUploadSession + chunked PUT.
+    # To exercise the chunked branch on a small test CSV, temporarily lower this to e.g. 100.
+    $simpleUploadCap = 4 * 1024 * 1024
+
     Write-Output "Uploading $($Bytes.Length) bytes to: $uploadPath"
+
+    if ($Bytes.Length -le $simpleUploadCap) {
+        $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/content"
+        try {
+            Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $Bytes -ContentType 'text/csv' | Out-Null
+            Write-Output "Upload complete (simple PUT)."
+        } catch { Write-Error "Failed to upload CSV to SharePoint: $_"; exit 1 }
+        return
+    }
+
+    $sessionUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/createUploadSession"
+    $sessionBody = @{ item = @{ '@microsoft.graph.conflictBehavior' = 'replace' } } | ConvertTo-Json
     try {
-        Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $Bytes -ContentType 'text/csv' | Out-Null
-        Write-Output "Upload complete."
-    } catch { Write-Error "Failed to upload CSV to SharePoint: $_"; exit 1 }
+        $session = Invoke-MgGraphRequest -Method POST -Uri $sessionUri -Body $sessionBody -ContentType 'application/json'
+    } catch { Write-Error "Failed to create upload session: $_"; exit 1 }
+    $uploadUrl = $session.uploadUrl
+    if (-not $uploadUrl) { Write-Error "createUploadSession returned no uploadUrl"; exit 1 }
+
+    $chunkSize = 5 * 1024 * 1024   # multiple of 320 KB required by Graph
+    $total  = $Bytes.Length
+    $offset = 0
+    while ($offset -lt $total) {
+        $end = [Math]::Min($offset + $chunkSize, $total) - 1
+        $len = $end - $offset + 1
+        $chunk = New-Object byte[] $len
+        [Array]::Copy($Bytes, $offset, $chunk, 0, $len)
+        $contentRange = "bytes $offset-$end/$total"
+        try {
+            Invoke-WebRequest -Uri $uploadUrl -Method Put `
+                -Body $chunk -ContentType 'application/octet-stream' `
+                -Headers @{ 'Content-Range' = $contentRange } `
+                -UseBasicParsing -ErrorAction Stop | Out-Null
+        } catch { Write-Error "Chunk upload failed at $contentRange : $_"; exit 1 }
+        $offset = $end + 1
+        Write-Output ("Uploaded {0:N0}/{1:N0} bytes" -f $offset, $total)
+    }
+    Write-Output "Upload complete (upload session)."
 }
 
 #############################################################

--- a/2. SharePoint/Single File/scripts/appreg/GetCopilotInteractions-SP-AppReg.ps1
+++ b/2. SharePoint/Single File/scripts/appreg/GetCopilotInteractions-SP-AppReg.ps1
@@ -193,15 +193,59 @@ function UploadToSharePoint {
     $encodedSegments = $uploadPath.Split('/') | ForEach-Object { [uri]::EscapeDataString($_) }
     $encodedPath = $encodedSegments -join '/'
 
-    $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/content"
+    # Graph caps simple PUT (root:/path:/content) at 4 MB. Larger files need an upload session
+    # with chunked PUTs and Content-Range headers. To exercise the chunked branch on a small
+    # test CSV, temporarily lower this to e.g. 100.
+    $simpleUploadCap = 4 * 1024 * 1024
+
     Write-Output "Uploading $($Bytes.Length) bytes to: $uploadPath"
 
-    try {
-        Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $Bytes -ContentType 'text/csv' | Out-Null
-        Write-Output "Upload complete."
-    } catch {
-        Write-Error "Failed to upload CSV to SharePoint: $_"; exit 1
+    if ($Bytes.Length -le $simpleUploadCap) {
+        $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/content"
+        try {
+            Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $Bytes -ContentType 'text/csv' | Out-Null
+            Write-Output "Upload complete (simple PUT)."
+        } catch {
+            Write-Error "Failed to upload CSV to SharePoint: $_"; exit 1
+        }
+        return
     }
+
+    # Large file: createUploadSession then chunked PUT with Content-Range.
+    $sessionUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/createUploadSession"
+    $sessionBody = @{ item = @{ '@microsoft.graph.conflictBehavior' = 'replace' } } | ConvertTo-Json
+    try {
+        $session = Invoke-MgGraphRequest -Method POST -Uri $sessionUri -Body $sessionBody -ContentType 'application/json'
+    } catch {
+        Write-Error "Failed to create upload session: $_"; exit 1
+    }
+    $uploadUrl = $session.uploadUrl
+    if (-not $uploadUrl) { Write-Error "createUploadSession returned no uploadUrl"; exit 1 }
+
+    # Upload session chunk size must be a multiple of 320 KB. 5 MB = 16 * 320 KB.
+    $chunkSize = 5 * 1024 * 1024
+    $total  = $Bytes.Length
+    $offset = 0
+
+    while ($offset -lt $total) {
+        $end = [Math]::Min($offset + $chunkSize, $total) - 1
+        $len = $end - $offset + 1
+        $chunk = New-Object byte[] $len
+        [Array]::Copy($Bytes, $offset, $chunk, 0, $len)
+        $contentRange = "bytes $offset-$end/$total"
+
+        try {
+            Invoke-WebRequest -Uri $uploadUrl -Method Put `
+                -Body $chunk -ContentType 'application/octet-stream' `
+                -Headers @{ 'Content-Range' = $contentRange } `
+                -UseBasicParsing -ErrorAction Stop | Out-Null
+        } catch {
+            Write-Error "Chunk upload failed at $contentRange : $_"; exit 1
+        }
+        $offset = $end + 1
+        Write-Output ("Uploaded {0:N0}/{1:N0} bytes" -f $offset, $total)
+    }
+    Write-Output "Upload complete (upload session)."
 }
 
 #############################################################

--- a/2. SharePoint/Single File/scripts/appreg/GetCopilotUsers-SP-AppReg.ps1
+++ b/2. SharePoint/Single File/scripts/appreg/GetCopilotUsers-SP-AppReg.ps1
@@ -145,12 +145,49 @@ function UploadToSharePoint {
     $uploadPath = if ([string]::IsNullOrWhiteSpace($cleanFolder)) { $FileName } else { "$cleanFolder/$FileName" }
     $encodedSegments = $uploadPath.Split('/') | ForEach-Object { [uri]::EscapeDataString($_) }
     $encodedPath = $encodedSegments -join '/'
-    $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/content"
+
+    # Graph caps simple PUT at 4 MB. Above that → createUploadSession + chunked PUT.
+    # To exercise the chunked branch on a small test CSV, temporarily lower this to e.g. 100.
+    $simpleUploadCap = 4 * 1024 * 1024
+
     Write-Output "Uploading $($Bytes.Length) bytes to: $uploadPath"
+
+    if ($Bytes.Length -le $simpleUploadCap) {
+        $uploadUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/content"
+        try {
+            Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $Bytes -ContentType 'text/csv' | Out-Null
+            Write-Output "Upload complete (simple PUT)."
+        } catch { Write-Error "Failed to upload CSV to SharePoint: $_"; exit 1 }
+        return
+    }
+
+    $sessionUri = "https://graph.microsoft.com/v1.0/drives/$DriveId/root:/${encodedPath}:/createUploadSession"
+    $sessionBody = @{ item = @{ '@microsoft.graph.conflictBehavior' = 'replace' } } | ConvertTo-Json
     try {
-        Invoke-MgGraphRequest -Method PUT -Uri $uploadUri -Body $Bytes -ContentType 'text/csv' | Out-Null
-        Write-Output "Upload complete."
-    } catch { Write-Error "Failed to upload CSV to SharePoint: $_"; exit 1 }
+        $session = Invoke-MgGraphRequest -Method POST -Uri $sessionUri -Body $sessionBody -ContentType 'application/json'
+    } catch { Write-Error "Failed to create upload session: $_"; exit 1 }
+    $uploadUrl = $session.uploadUrl
+    if (-not $uploadUrl) { Write-Error "createUploadSession returned no uploadUrl"; exit 1 }
+
+    $chunkSize = 5 * 1024 * 1024   # multiple of 320 KB required by Graph
+    $total  = $Bytes.Length
+    $offset = 0
+    while ($offset -lt $total) {
+        $end = [Math]::Min($offset + $chunkSize, $total) - 1
+        $len = $end - $offset + 1
+        $chunk = New-Object byte[] $len
+        [Array]::Copy($Bytes, $offset, $chunk, 0, $len)
+        $contentRange = "bytes $offset-$end/$total"
+        try {
+            Invoke-WebRequest -Uri $uploadUrl -Method Put `
+                -Body $chunk -ContentType 'application/octet-stream' `
+                -Headers @{ 'Content-Range' = $contentRange } `
+                -UseBasicParsing -ErrorAction Stop | Out-Null
+        } catch { Write-Error "Chunk upload failed at $contentRange : $_"; exit 1 }
+        $offset = $end + 1
+        Write-Output ("Uploaded {0:N0}/{1:N0} bytes" -f $offset, $total)
+    }
+    Write-Output "Upload complete (upload session)."
 }
 
 #############################################################

--- a/3. Fabric/README.md
+++ b/3. Fabric/README.md
@@ -159,7 +159,7 @@ You have **three** routes depending on what you're willing to stand up:
 
 1. **Easiest — Fabric Lakehouse Shortcut.** Create a Shortcut from your Fabric Lakehouse to the ADL container holding raw CSVs. The Shortcut makes the ADL data appear as a Lakehouse `Files/` reference. Run the notebook unchanged. Best of both worlds — your data stays in ADL, Fabric does the compute.
 
-2. **No Fabric — use the [`Manual CSV`](../Manual%20CSV/) `sharepoint only` PBIT instead.** Point its `Copilot Interactions File` parameter at `https://<account>.dfs.core.windows.net/<container>/<path>/parsed.csv`. Skips the Spark step entirely; works for tenants that already pre-parse upstream and just need Power BI to consume the result.
+2. **No Fabric — use the [`1. Manual/`](../1.%20Manual/) PBIT instead.** Point its `Copilot Interactions File` parameter at `https://<account>.dfs.core.windows.net/<container>/<path>/parsed.csv`. Skips the Spark step entirely; works for tenants that already pre-parse upstream and just need Power BI to consume the result.
 
 3. **Pure ADL + Databricks.** Mount the ADL container in Databricks (or use Unity Catalog external locations), then run the notebook from there as in the Databricks section above.
 

--- a/3. Fabric/scripts/appreg/README.md
+++ b/3. Fabric/scripts/appreg/README.md
@@ -16,7 +16,7 @@ Lakehouse notebook (../../notebooks/) parses + writes Delta tables
 PBI Direct Lake reads Delta tables → near-instant refresh
 ```
 
-If you want **direct upload to SharePoint** instead, use the [`../../../SharePoint/Single File/scripts/appreg/`](../../../SharePoint/Single%20File/scripts/appreg/) variants — they upload to a SharePoint document library directly and produce the **NatWest pre-parsed format** (different schema).
+If you want **direct upload to SharePoint** instead, use the [`../../../2. SharePoint/Single File/scripts/appreg/`](../../../2.%20SharePoint/Single%20File/scripts/appreg/) variants — they upload to a SharePoint document library directly and produce the **NatWest pre-parsed format** (different schema).
 
 ## Scripts in this folder
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ Pick the path that matches your environment. Each folder is self-contained — R
 
 | Path | Folder | Best when… | Volume ceiling |
 |---|---|---|---|
-| **Manual** | [`Manual/`](Manual/) | One-off, ad-hoc, or single-user. Customer manually exports audit CSV from Purview UI, drops into the local PBIT | < ~100K events lifetime |
-| **SharePoint — Single File** *(recommended default)* | [`SharePoint/Single File/`](SharePoint/Single%20File/) | Scheduled refresh in PBI Service without a Gateway. Script overwrites one CSV per refresh — no folder iteration, no privacy firewall errors | Rolling 30 days, refreshes weekly or daily |
-| **SharePoint — Folder** *(advanced)* | [`SharePoint/Folder/`](SharePoint/Folder/) | Need > 30 days of accumulated history but no Fabric. Folder iteration auto-unions all daily CSVs | Up to 180 days (Graph cap), heavier PBI memory footprint |
-| **Fabric / Lakehouse** | [`Fabric/`](Fabric/) | Have Fabric capacity. JSON parsing happens upstream in a notebook → best performance, multi-year history, sub-second dashboard | Millions of events, multi-year |
+| **Manual** | [`1. Manual/`](1.%20Manual/) | One-off, ad-hoc, or single-user. Customer manually exports audit CSV from Purview UI, drops into the local PBIT | < ~100K events lifetime |
+| **SharePoint — Single File** *(recommended default)* | [`2. SharePoint/Single File/`](2.%20SharePoint/Single%20File/) | Scheduled refresh in PBI Service without a Gateway. Script overwrites one CSV per refresh — no folder iteration, no privacy firewall errors | Rolling 30 days, refreshes weekly or daily |
+| **SharePoint — Folder** *(advanced)* | [`2. SharePoint/Folder/`](2.%20SharePoint/Folder/) | Need > 30 days of accumulated history but no Fabric. Folder iteration auto-unions all daily CSVs | Up to 180 days (Graph cap), heavier PBI memory footprint |
+| **Fabric / Lakehouse** | [`3. Fabric/`](3.%20Fabric/) | Have Fabric capacity. JSON parsing happens upstream in a notebook → best performance, multi-year history, sub-second dashboard | Millions of events, multi-year |
 
 Inside each path:
 - The PBIT for that pattern (and a README explaining what parameters to fill in)
@@ -352,29 +352,30 @@ Refer back to the [**Choose your deployment path**](#-choose-your-deployment-pat
 
 | Path | PBIT | Setup guide |
 |---|---|---|
-| **Manual CSV / SharePoint single file** | `Manual CSV/AI-in-One Dashboard - csv only.pbit` *(local)* or `Manual CSV/AI-in-One Dashboard - sharepoint only.pbit` *(single SharePoint URL)* | [`Manual CSV/README.md`](Manual%20CSV/README.md) |
-| **SharePoint Refresh** *(folder, scheduled refresh)* | `SharePoint Refresh/AI-in-One Dashboard - Sharepoint Refresh.pbit` | [`SharePoint Refresh/README.md`](SharePoint%20Refresh/README.md) |
-| **Fabric / Lakehouse** *(upstream JSON parsing, large tenants)* | `Fabric/AI-in-One Dashboard - Fabric.pbit` | [`Fabric/README.md`](Fabric/README.md) |
+| **Manual** | `1. Manual/AI-in-One Dashboard.pbit` (single local CSV) | [`1. Manual/README.md`](1.%20Manual/README.md) |
+| **SharePoint — Single File** *(recommended default for scheduled refresh)* | `2. SharePoint/Single File/AI-in-One Dashboard.pbit` | [`2. SharePoint/Single File/README.md`](2.%20SharePoint/Single%20File/README.md) |
+| **SharePoint — Folder** *(advanced; >30 days history without Fabric)* | `2. SharePoint/Folder/AI-in-One Dashboard - SP Folder.pbit` | [`2. SharePoint/Folder/README.md`](2.%20SharePoint/Folder/README.md) |
+| **Fabric / Lakehouse** *(upstream JSON parsing, large tenants)* | `3. Fabric/AI-in-One Dashboard - Fabric.pbit` | [`3. Fabric/README.md`](3.%20Fabric/README.md) |
 
 Each per-folder README has the **definitive setup steps, parameter values, and troubleshooting** for that variant — including SharePoint folder URL conventions, Service refresh / credential setup, and (for Fabric) the upstream notebook + Lakehouse provisioning.
 
 ### Common parameters across templates
 
-All three template paths share the same four parameters — only the *value format* changes (local path vs SharePoint URL vs SharePoint folder):
+All four template paths share the same four parameters — only the *value format* changes (local path vs SharePoint URL vs SharePoint folder vs Lakehouse table):
 
 | Parameter | What it points at |
 |---|---|
-| **Copilot Interactions File** | Audit-log CSV from Step 1 (or the SharePoint folder of audit CSVs in the SharePoint Refresh path) |
+| **Copilot Interactions File** | Audit-log CSV from Step 1 (or the SharePoint folder of audit CSVs in the SharePoint Folder path) |
 | **Copilot Licensed Users** | Licensed-users CSV from Step 2 |
 | **Org Data File** | Org-data CSV from Step 4 |
 | **Agent 365** *(optional)* | Agent 365 inventory file from Step 3 |
 
-After supplying parameters, click **Load**. First refresh on a moderate dataset takes 5–15 minutes; large tenants on the Manual / SharePoint Refresh paths may need 30+ minutes (use the Fabric path if you're hitting the 1 GB / 2-hour Service caps).
+After supplying parameters, click **Load**. First refresh on a moderate dataset takes 5–15 minutes; large tenants on the Manual / SharePoint paths may need 30+ minutes (use the Fabric path if you're hitting the 1 GB / 2-hour Service caps).
 
 ### Generic troubleshooting
 
 - **"File not found" / `DataSource.Error`** — local paths must be absolute (e.g. `C:\Data\file.csv`, not `.\file.csv`). For SharePoint URLs, copy the **document URL**, not the share link.
-- **Refresh times out in Power BI Service (>2 hours)** — switch to the [`Fabric/`](Fabric/) deployment path. JSON parsing happens upstream in a Lakehouse / notebook, leaving the dataset as a thin pass-through against a flat Delta table.
+- **Refresh times out in Power BI Service (>2 hours)** — switch to the [`3. Fabric/`](3.%20Fabric/) deployment path. JSON parsing happens upstream in a Lakehouse / notebook, leaving the dataset as a thin pass-through against a flat Delta table.
 - **`Formula.Firewall: Query references other queries…`** — privacy-level mismatch when combining sources. In Power BI Desktop: **File → Options → Current File → Privacy → Combine data without privacy**. In Service: dataset Settings → Data source credentials → set **Privacy: None** for SharePoint sources.
 - **Path-specific issues** — see the troubleshooting section in each per-folder README.
 


### PR DESCRIPTION
Graph silently redirects PUT root:/path:/content uploads >4 MB to a SharePoint upload session, but the redirected request needs a Content-Range: bytes X-Y/TOTAL header that Invoke-MgGraphRequest doesn't send — so SharePoint rejects with
"Content-Range must include a total length".

UploadToSharePoint now branches on size: <=4 MB uses simple PUT (unchanged); >4 MB calls createUploadSession then PUTs 5 MB chunks with explicit Content-Range headers.

Affects all 3 SP-AppReg runbooks (Interactions, Users, EntraOrgData) in both Single File/ and Folder/ paths.

Tested against demo tenant (m365cpi94179096): both branches work end-to-end (33 KB simple PUT path; chunked path with threshold lowered to 100 bytes for validation).