### PR TITLE
Schema-qualify OUTPUT_TABLE in legacy CSV-loader notebooks

### DIFF
--- a/3. Fabric/notebooks/Copilot_Audit_Log_Parser.ipynb
+++ b/3. Fabric/notebooks/Copilot_Audit_Log_Parser.ipynb
@@ -1,1 +1,653 @@
-{"cells":[{"cell_type":"markdown","source":["# Copilot Audit Log Parser\n","\n","Parses raw `CopilotInteraction` audit-log CSVs (with the nested `AuditData` JSON column) into a flat Delta table consumed by the **AI-in-One Dashboard** and **AI Business Value Dashboard** — Path D / Fabric variant.\n","\n","**Inputs**: one or more raw audit CSVs landed in `Files/audit_raw/` of this Lakehouse. Expected columns: `RecordId, CreationDate, RecordType, Operation, AuditData, AssociatedAdminUnits, AssociatedAdminUnitsNames`.\n","\n","**Output**: Lakehouse Delta table `dbo.Copilot_Interactions_Parsed` with the schema the PBIT expects (one row per prompt × accessed-resource).\n","\n","**Schedule**: run on the same cadence as your audit-log export (typically daily). Configure via the **Schedule** button at the top of this notebook.\n"],"metadata":{},"id":"64d20733-70b6-4089-9177-7be7ebac0d38"},{"cell_type":"markdown","source":["## 1. Configuration\n","Adjust paths if your raw CSVs land somewhere other than `Files/audit_raw/`.\n"],"metadata":{},"id":"f74e3f96-9613-4b09-8552-7cadb94ebc4b"},{"cell_type":"code","source":["# === CONFIG ===\n","RAW_PATH    = 'Files/audit_raw/*.csv'        # raw audit CSVs from the export script / pipeline\n","OUTPUT_TABLE = 'Copilot_Interactions_Parsed' # Delta table name (consumed by the PBIT)\n","WRITE_MODE  = 'overwrite'                    # use 'append' + a watermark column for incremental\n"],"outputs":[{"output_type":"display_data","data":{"application/vnd.livy.statement-meta+json":{"spark_pool":null,"statement_id":6,"statement_ids":[6],"state":"finished","livy_statement_state":"available","spark_jobs_updating":false,"session_id":"4f5617cc-9be1-4d31-be0d-4859fa4772f9","normalized_state":"finished","queued_time":"2026-04-30T17:54:55.9784962Z","session_start_time":null,"execution_start_time":"2026-04-30T17:54:55.9797352Z","execution_finish_time":"2026-04-30T17:54:56.2523747Z","parent_msg_id":"7d0e2d1c-0847-407c-828c-9a0579c6f268"},"text/plain":"StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 6, Finished, Available, Finished, False)"},"metadata":{}}],"execution_count":4,"metadata":{"microsoft":{"language":"python","language_group":"synapse_pyspark"}},"id":"e0dcc970-2087-42ae-88b2-8f353b885554"},{"cell_type":"markdown","source":["## 2. Define the AuditData JSON schema\n","Only the fields the PBIT consumes — adding more is harmless but slows the parse.\n"],"metadata":{},"id":"e8dbd93d-5340-479e-838b-49d277bcca7b"},{"cell_type":"code","source":["from pyspark.sql import functions as F\n","from pyspark.sql.types import (\n","    StructType, StructField, StringType, ArrayType\n",")\n","\n","audit_schema = StructType([\n","    StructField('CreationTime', StringType()),\n","    StructField('UserId', StringType()),\n","    StructField('Workload', StringType()),\n","    StructField('ApplicationName', StringType()),\n","    StructField('ClientRegion', StringType()),\n","    StructField('AgentId', StringType()),\n","    StructField('AgentName', StringType()),\n","    StructField('AppIdentity', StructType([\n","        StructField('AppId', StringType()),\n","        StructField('DisplayName', StringType()),\n","        StructField('PublisherId', StringType()),\n","    ])),\n","    StructField('CopilotEventData', StructType([\n","        StructField('AppHost', StringType()),\n","        StructField('ThreadId', StringType()),\n","        StructField('SensitivityLabelId', StringType()),\n","        StructField('Contexts', ArrayType(StructType([\n","            StructField('Type', StringType())\n","        ]))),\n","        StructField('AISystemPlugin', ArrayType(StructType([\n","            StructField('Id', StringType()),\n","            StructField('Name', StringType())\n","        ]))),\n","        StructField('ModelTransparencyDetails', ArrayType(StructType([\n","            StructField('ModelName', StringType())\n","        ]))),\n","        StructField('AccessedResources', ArrayType(StructType([\n","            StructField('Type', StringType()),\n","            StructField('Action', StringType()),\n","            StructField('SiteUrl', StringType()),\n","            StructField('SensitivityLabelId', StringType()),\n","        ]))),\n","        StructField('Messages', ArrayType(StructType([\n","            StructField('Id', StringType()),\n","            StructField('isPrompt', StringType())\n","        ]))),\n","    ])),\n","])"],"outputs":[{"output_type":"display_data","data":{"application/vnd.livy.statement-meta+json":{"spark_pool":null,"statement_id":7,"statement_ids":[7],"state":"finished","livy_statement_state":"available","spark_jobs_updating":false,"session_id":"4f5617cc-9be1-4d31-be0d-4859fa4772f9","normalized_state":"finished","queued_time":"2026-04-30T17:54:56.0935546Z","session_start_time":null,"execution_start_time":"2026-04-30T17:54:56.2545613Z","execution_finish_time":"2026-04-30T17:54:56.5230627Z","parent_msg_id":"9efcd0a5-08cf-45b3-a9a8-6dddd2a48f1b"},"text/plain":"StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 7, Finished, Available, Finished, False)"},"metadata":{}}],"execution_count":5,"metadata":{"microsoft":{"language":"python","language_group":"synapse_pyspark"}},"id":"ada002dd-9755-478f-bd8c-e6fe279393c8"},{"cell_type":"markdown","source":["## 3. Read raw CSVs and parse JSON\n"],"metadata":{},"id":"8eeef224-0348-4f4a-860c-63cbeac245e0"},{"cell_type":"code","source":["raw = (spark.read\n","    .option('header', 'true')\n","    .option('multiline', 'true')\n","    .option('escape', '\"')\n","    .csv(RAW_PATH))\n","\n","print(f'Raw rows: {raw.count():,}')\n","\n","parsed = (raw\n","    .filter(F.col('AuditData').isNotNull() & (F.length('AuditData') > 10))\n","    .withColumn('j', F.from_json('AuditData', audit_schema))\n","    .filter(F.col('j').isNotNull()))\n"],"outputs":[{"output_type":"display_data","data":{"application/vnd.livy.statement-meta+json":{"spark_pool":null,"statement_id":8,"statement_ids":[8],"state":"finished","livy_statement_state":"available","spark_jobs_updating":false,"session_id":"4f5617cc-9be1-4d31-be0d-4859fa4772f9","normalized_state":"finished","queued_time":"2026-04-30T17:54:56.4001378Z","session_start_time":null,"execution_start_time":"2026-04-30T17:54:56.5250175Z","execution_finish_time":"2026-04-30T17:55:09.7063546Z","parent_msg_id":"f5e574b3-9bec-49ea-93e9-5d9286317fbb"},"text/plain":"StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 8, Finished, Available, Finished, False)"},"metadata":{}},{"output_type":"stream","name":"stdout","text":["Raw rows: 376,556\n"]}],"execution_count":6,"metadata":{"microsoft":{"language":"python","language_group":"synapse_pyspark"}},"id":"c60d5d63-7416-4129-93c4-56b287990462"},{"cell_type":"code","source":["# Inspect distinct isPrompt values and a sample Messages structure\n","from pyspark.sql import functions as F\n","\n","print(\"Distinct isPrompt values:\")\n","parsed.selectExpr(\"explode(j.CopilotEventData.Messages) as msg\") \\\n","      .select(\"msg.isPrompt\") \\\n","      .distinct() \\\n","      .show(50, truncate=False)\n","\n","print(\"Sample Messages structures:\")\n","parsed.select(F.col(\"j.CopilotEventData.Messages\").alias(\"Messages\")).show(5, truncate=False)"],"outputs":[{"output_type":"display_data","data":{"application/vnd.livy.statement-meta+json":{"spark_pool":null,"statement_id":16,"statement_ids":[16],"state":"finished","livy_statement_state":"available","spark_jobs_updating":false,"session_id":"4f5617cc-9be1-4d31-be0d-4859fa4772f9","normalized_state":"finished","queued_time":"2026-04-30T18:07:30.1822247Z","session_start_time":null,"execution_start_time":"2026-04-30T18:07:30.1834301Z","execution_finish_time":"2026-04-30T18:07:53.912016Z","parent_msg_id":"3c6ac2f9-4ba9-47a3-b8c7-cfc8edf1a992"},"text/plain":"StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 16, Finished, Available, Finished, False)"},"metadata":{}},{"output_type":"stream","name":"stdout","text":["Distinct isPrompt values:\n+--------+\n|isPrompt|\n+--------+\n|false   |\n|true    |\n+--------+\n\nSample Messages structures:\n+-----------------------------------------------------------------------+\n|Messages                                                               |\n+-----------------------------------------------------------------------+\n|[{1749140036296, true}, {1749140036456, false}, {1749140036561, false}]|\n|[{1748449582440, true}, {1748449582582, false}]                        |\n|[{1742566321800, true}, {1742566321854, false}]                        |\n|[{1748945344625, true}, {1748945344776, false}]                        |\n|[{1744366239847, true}, {1744366239992, false}]                        |\n+-----------------------------------------------------------------------+\nonly showing top 5 rows\n\n"]}],"execution_count":14,"metadata":{"microsoft":{"language":"python","language_group":"synapse_pyspark"},"metadata":{"microsoft":{"language":"python","language_group":"synapse_pyspark"}},"advisor":{"adviceMetadata":"{\"artifactId\":\"f19458c8-258e-412f-98cd-3291e495d406\",\"activityId\":\"4f5617cc-9be1-4d31-be0d-4859fa4772f9\",\"applicationId\":\"application_1777570835767_0001\",\"jobGroupId\":\"16\",\"advices\":{\"info\":1}}"}},"id":"1cbe71a4-43b5-4fbc-8971-7904295c15ee"},{"cell_type":"markdown","source":["## 4. Flatten + fan out per (prompt × resource)\n","Mirrors the existing AI-in-One M-query exactly — drop responses, expand resources.\n"],"metadata":{},"id":"f954fa80-31e3-42b4-b3a9-0f638d430b6b"},{"cell_type":"code","source":["from pyspark.sql.types import StringType\n","from pyspark.sql import functions as F\n","\n","# Flatten and fan out per (prompt × resource)\n","flat = (\n","    parsed\n","    .select(\n","        F.col('j.CreationTime').cast('timestamp').alias('CreationDate'),\n","        F.col('j.AgentId').alias('AgentId'),\n","        F.col('j.AgentName').alias('AgentName'),\n","        F.col('j.AppIdentity.AppId').alias('AppIdentity_AppId'),\n","        F.col('j.AppIdentity.DisplayName').alias('AppIdentity_DisplayName'),\n","        F.col('j.AppIdentity.PublisherId').alias('AppIdentity_PublisherId'),\n","        F.col('j.ApplicationName').alias('ApplicationName'),\n","        F.col('j.ClientRegion').alias('ClientRegion'),\n","        F.col('j.UserId').alias('Audit_UserId'),\n","        F.lower(F.trim(F.col('j.UserId'))).alias('Audit_UserId_Normalized'),\n","        F.col('j.Workload').alias('Workload'),\n","        F.col('j.CopilotEventData.AppHost').alias('AppHost'),\n","        F.col('j.CopilotEventData.ThreadId').alias('ThreadId'),\n","        F.col('j.CopilotEventData.SensitivityLabelId').alias('SensitivityLabelId'),\n","        F.col('j.CopilotEventData.Contexts')[0]['Type'].alias('Context_Type'),\n","        # Corrected bracket/parenthesis and keep first AISystemPlugin element\n","        F.col('j.CopilotEventData.AISystemPlugin')[0]['Id'].alias('AISystemPlugin_Id'),\n","        F.col('j.CopilotEventData.AISystemPlugin')[0]['Name'].alias('AISystemPlugin_Name'),\n","        F.col('j.CopilotEventData.ModelTransparencyDetails')[0]['ModelName']\n","            .alias('ModelTransparencyDetails_ModelName'),\n","        F.col('j.CopilotEventData.AccessedResources').alias('Resources'),\n","        F.col('j.CopilotEventData.Messages').alias('Messages'),\n","        F.size('j.CopilotEventData.AccessedResources').alias('Resource_Count'),\n","    )\n","    # One row per message\n","    .withColumn('msg', F.explode('Messages'))\n","    # Your data has isPrompt as true/false; cast to string and compare case-insensitively\n","    .filter(F.lower(F.col('msg.isPrompt').cast('string')) == 'true')\n","    # One row per accessed resource; if none, synthesize a single null resource\n","    .withColumn(\n","        'res',\n","        F.explode_outer(\n","            F.when(F.size('Resources') > 0, F.col('Resources'))\n","             .otherwise(F.array(F.struct(\n","                 F.lit(None).cast(StringType()).alias('Type'),\n","                 F.lit(None).cast(StringType()).alias('Action'),\n","                 F.lit(None).cast(StringType()).alias('SiteUrl'),\n","                 F.lit(None).cast(StringType()).alias('SensitivityLabelId'),\n","             )))\n","        ),\n","    )\n","    .select(\n","        'CreationDate', 'AgentId', 'AgentName',\n","        'AppIdentity_AppId', 'AppIdentity_DisplayName', 'AppIdentity_PublisherId',\n","        'ApplicationName', 'ClientRegion',\n","        'Audit_UserId', 'Audit_UserId_Normalized', 'Workload',\n","        'AppHost', 'ThreadId', 'SensitivityLabelId',\n","        'Context_Type',\n","        'AISystemPlugin_Id', 'AISystemPlugin_Name',\n","        'ModelTransparencyDetails_ModelName',\n","        F.col('res.Type').alias('AccessedResource_Type'),\n","        F.col('res.Action').alias('AccessedResource_Action'),\n","        F.col('res.SiteUrl').alias('AccessedResource_SiteUrl'),\n","        F.col('res.SensitivityLabelId').alias('AccessedResource_SensitivityLabelId'),\n","        F.col('msg.Id').alias('Message_Id'),\n","        F.col('msg.isPrompt').alias('Message_isPrompt'),\n","        F.coalesce(F.col('Resource_Count'), F.lit(1)).alias('Resource_Count'),\n","        F.to_date('CreationDate').alias('InteractionDate'),\n","        F.expr(\"date_trunc('week', CreationDate)\").cast('date').alias('WeekStart'),\n","        F.expr(\"date_trunc('month', CreationDate)\").cast('date').alias('MonthStart'),\n","    )\n",")"],"outputs":[{"output_type":"display_data","data":{"application/vnd.livy.statement-meta+json":{"spark_pool":null,"statement_id":19,"statement_ids":[19],"state":"finished","livy_statement_state":"available","spark_jobs_updating":false,"session_id":"4f5617cc-9be1-4d31-be0d-4859fa4772f9","normalized_state":"finished","queued_time":"2026-04-30T18:11:40.4546256Z","session_start_time":null,"execution_start_time":"2026-04-30T18:11:40.456382Z","execution_finish_time":"2026-04-30T18:11:41.2191782Z","parent_msg_id":"50a8e6cc-ed15-4ff9-92be-98562da33608"},"text/plain":"StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 19, Finished, Available, Finished, False)"},"metadata":{}}],"execution_count":17,"metadata":{"microsoft":{"language":"python","language_group":"synapse_pyspark"}},"id":"d27db198-8937-45f6-9f1e-3b508a911ffb"},{"cell_type":"markdown","source":["## 5. Derive `Agent_TitleID`\n","Same logic as the M-query: pull the slug after the standard CopilotStudio prefix or before the first `.` for `P_` / `T_` declarative IDs.\n"],"metadata":{},"id":"70467f52-f89a-4699-8835-a42b1b52048c"},{"cell_type":"code","source":["flat = flat.withColumn('Agent_TitleID', F.expr(r'''\n","    CASE\n","      WHEN AgentId IS NULL THEN NULL\n","      WHEN AgentId LIKE '%CopilotStudio.Declarative.%' THEN\n","           split(split(AgentId, 'CopilotStudio\\\\.Declarative\\\\.')[1], '\\\\.')[0]\n","      WHEN AgentId LIKE 'P\\\\_%' OR AgentId LIKE 'T\\\\_%' THEN\n","           split(AgentId, '\\\\.')[0]\n","      ELSE NULL\n","    END\n","'''))\n"],"outputs":[{"output_type":"display_data","data":{"application/vnd.livy.statement-meta+json":{"spark_pool":null,"statement_id":20,"statement_ids":[20],"state":"finished","livy_statement_state":"available","spark_jobs_updating":false,"session_id":"4f5617cc-9be1-4d31-be0d-4859fa4772f9","normalized_state":"finished","queued_time":"2026-04-30T18:11:49.9474622Z","session_start_time":null,"execution_start_time":"2026-04-30T18:11:49.9486798Z","execution_finish_time":"2026-04-30T18:11:50.179367Z","parent_msg_id":"5edda97b-473b-49e8-839c-50cb484e0da2"},"text/plain":"StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 20, Finished, Available, Finished, False)"},"metadata":{}}],"execution_count":18,"metadata":{"microsoft":{"language":"python","language_group":"synapse_pyspark"}},"id":"a64ee3a1-bd87-417c-8e97-de04e4f15fb4"},{"cell_type":"markdown","source":["## 6. Write to Lakehouse Delta table\n"],"metadata":{},"id":"7cecb9f8-d6e9-40ca-834f-3d7652da2007"},{"cell_type":"code","source":["(flat.write\n","    .format('delta')\n","    .mode(WRITE_MODE)\n","    .option('overwriteSchema', 'true')\n","    .saveAsTable(OUTPUT_TABLE))\n","\n","print(f'Rows written to {OUTPUT_TABLE}: {spark.table(OUTPUT_TABLE).count():,}')"],"outputs":[{"output_type":"display_data","data":{"application/vnd.livy.statement-meta+json":{"spark_pool":null,"statement_id":21,"statement_ids":[21],"state":"finished","livy_statement_state":"available","spark_jobs_updating":false,"session_id":"4f5617cc-9be1-4d31-be0d-4859fa4772f9","normalized_state":"finished","queued_time":"2026-04-30T18:11:56.1988544Z","session_start_time":null,"execution_start_time":"2026-04-30T18:11:56.1999621Z","execution_finish_time":"2026-04-30T18:12:30.2177326Z","parent_msg_id":"e56a58ca-b3d4-46b7-b2e7-73cbcde1f46d"},"text/plain":"StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 21, Finished, Available, Finished, False)"},"metadata":{}},{"output_type":"stream","name":"stdout","text":["Rows written to Copilot_Interactions_Parsed: 782,397\n"]}],"execution_count":19,"metadata":{"microsoft":{"language":"python","language_group":"synapse_pyspark"},"advisor":{"adviceMetadata":"{\"artifactId\":\"f19458c8-258e-412f-98cd-3291e495d406\",\"activityId\":\"4f5617cc-9be1-4d31-be0d-4859fa4772f9\",\"applicationId\":\"application_1777570835767_0001\",\"jobGroupId\":\"21\",\"advices\":{\"info\":1}}"}},"id":"deddee2b-d91b-4a33-b9a9-4de3b895810b"},{"cell_type":"markdown","source":["## 7. Verify\n","Spot-check the output. Expect populated `AISystemPlugin_Id` (e.g. `BingWebSearch`), `Workload`, `AppHost`, etc.\n"],"metadata":{},"id":"8fc21017-b971-4e4f-a815-26a1c1c7d485"},{"cell_type":"code","source":["spark.table(OUTPUT_TABLE).select(\n","    'AISystemPlugin_Id', 'Workload', 'AppHost'\n",").groupBy('AISystemPlugin_Id', 'Workload', 'AppHost').count().orderBy(F.desc('count')).show(20, truncate=False)"],"outputs":[{"output_type":"display_data","data":{"application/vnd.livy.statement-meta+json":{"spark_pool":null,"statement_id":22,"statement_ids":[22],"state":"finished","livy_statement_state":"available","spark_jobs_updating":false,"session_id":"4f5617cc-9be1-4d31-be0d-4859fa4772f9","normalized_state":"finished","queued_time":"2026-04-30T18:12:39.6638934Z","session_start_time":null,"execution_start_time":"2026-04-30T18:12:39.6650301Z","execution_finish_time":"2026-04-30T18:12:42.756856Z","parent_msg_id":"2473c213-edc2-4216-abea-79deb4822bc3"},"text/plain":"StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 22, Finished, Available, Finished, False)"},"metadata":{}},{"output_type":"stream","name":"stdout","text":["+-----------------+--------+--------------+------+\n|AISystemPlugin_Id|Workload|AppHost       |count |\n+-----------------+--------+--------------+------+\n|BingWebSearch    |Copilot |Teams         |327659|\n|BingWebSearch    |Copilot |Office        |240731|\n|NULL             |Copilot |Outlook       |71106 |\n|NULL             |Copilot |Word          |34380 |\n|BingWebSearch    |Copilot |Outlook       |23122 |\n|NULL             |Copilot |Teams         |15682 |\n|NULL             |Copilot |Unknown       |14632 |\n|NULL             |Copilot |Office        |12773 |\n|NULL             |Copilot |PowerPoint    |6630  |\n|EnterpriseSearch |Copilot |Teams         |5533  |\n|NULL             |Copilot |Excel         |5456  |\n|NULL             |Copilot |Copilot Studio|4721  |\n|NULL             |Copilot |Forms         |3279  |\n|NULL             |Copilot |Designer      |3234  |\n|BingWebSearch    |Copilot |Edge          |1649  |\n|NULL             |Copilot |Autonomous    |1469  |\n|NULL             |Copilot |OneNote       |1400  |\n|EnterpriseSearch |Copilot |Stream        |1160  |\n|BingWebSearch    |Copilot |Word          |1144  |\n|NULL             |Copilot |SharePoint    |891   |\n+-----------------+--------+--------------+------+\nonly showing top 20 rows\n\n"]}],"execution_count":20,"metadata":{"microsoft":{"language":"python","language_group":"synapse_pyspark"}},"id":"1459a03f-da19-4d55-aedb-fe9f1009ea23"},{"cell_type":"markdown","source":["---\n","**Connect the PBIT**: open the **Fabric variant** of the AI-in-One or AI Business Value Dashboard PBIT, supply two parameters when prompted:\n","- `Fabric SQL Endpoint` = `<workspace-guid>.datawarehouse.fabric.microsoft.com` (find in Lakehouse settings → SQL endpoint)\n","- `Lakehouse Database` = the lakehouse name (e.g. `CopilotAnalytics`)\n","\n","The PBIT will source `dbo.Copilot_Interactions_Parsed` directly. Refresh becomes a near-instant data copy (or zero-copy with Direct Lake mode).\n"],"metadata":{},"id":"0ff75101-1a0e-411e-bccb-19dfc5821f54"}],"metadata":{"language_info":{"name":"python"},"kernel_info":{"name":"synapse_pyspark"},"kernelspec":{"display_name":"Synapse PySpark","language":"Python","name":"synapse_pyspark"},"a365ComputeOptions":null,"sessionKeepAliveTimeout":0,"microsoft":{"language":"python","language_group":"synapse_pyspark","ms_spell_check":{"ms_spell_check_language":"en"}},"nteract":{"version":"nteract-front-end@1.0.0"},"spark_compute":{"compute_id":"/trident/default","session_options":{"conf":{"spark.synapse.nbs.session.timeout":"1200000"}}},"dependencies":{"lakehouse":{"default_lakehouse":"eb233254-0200-4793-822c-a1ddb4a5cc2c","default_lakehouse_name":"CopilotAnalytics","default_lakehouse_workspace_id":"46590cf4-e16c-402e-a2b2-13e3e8c69b2e","known_lakehouses":[{"id":"eb233254-0200-4793-822c-a1ddb4a5cc2c"}]}}},"nbformat":4,"nbformat_minor":5}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "source": [
+    "# Copilot Audit Log Parser\n",
+    "\n",
+    "Parses raw `CopilotInteraction` audit-log CSVs (with the nested `AuditData` JSON column) into a flat Delta table consumed by the **AI-in-One Dashboard** and **AI Business Value Dashboard** — Path D / Fabric variant.\n",
+    "\n",
+    "**Inputs**: one or more raw audit CSVs landed in `Files/audit_raw/` of this Lakehouse. Expected columns: `RecordId, CreationDate, RecordType, Operation, AuditData, AssociatedAdminUnits, AssociatedAdminUnitsNames`.\n",
+    "\n",
+    "**Output**: Lakehouse Delta table `dbo.Copilot_Interactions_Parsed` with the schema the PBIT expects (one row per prompt × accessed-resource).\n",
+    "\n",
+    "**Schedule**: run on the same cadence as your audit-log export (typically daily). Configure via the **Schedule** button at the top of this notebook.\n"
+   ],
+   "metadata": {},
+   "id": "64d20733-70b6-4089-9177-7be7ebac0d38"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## 1. Configuration\n",
+    "Adjust paths if your raw CSVs land somewhere other than `Files/audit_raw/`.\n"
+   ],
+   "metadata": {},
+   "id": "f74e3f96-9613-4b09-8552-7cadb94ebc4b"
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# === CONFIG ===\n",
+    "RAW_PATH    = 'Files/audit_raw/*.csv'        # raw audit CSVs from the export script / pipeline\n",
+    "OUTPUT_TABLE = 'dbo.Copilot_Interactions_Parsed' # Delta table name (consumed by the PBIT)\n",
+    "WRITE_MODE  = 'overwrite'                    # use 'append' + a watermark column for incremental\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.livy.statement-meta+json": {
+       "spark_pool": null,
+       "statement_id": 6,
+       "statement_ids": [
+        6
+       ],
+       "state": "finished",
+       "livy_statement_state": "available",
+       "spark_jobs_updating": false,
+       "session_id": "4f5617cc-9be1-4d31-be0d-4859fa4772f9",
+       "normalized_state": "finished",
+       "queued_time": "2026-04-30T17:54:55.9784962Z",
+       "session_start_time": null,
+       "execution_start_time": "2026-04-30T17:54:55.9797352Z",
+       "execution_finish_time": "2026-04-30T17:54:56.2523747Z",
+       "parent_msg_id": "7d0e2d1c-0847-407c-828c-9a0579c6f268"
+      },
+      "text/plain": "StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 6, Finished, Available, Finished, False)"
+     },
+     "metadata": {}
+    }
+   ],
+   "execution_count": 4,
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "synapse_pyspark"
+    }
+   },
+   "id": "e0dcc970-2087-42ae-88b2-8f353b885554"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## 2. Define the AuditData JSON schema\n",
+    "Only the fields the PBIT consumes — adding more is harmless but slows the parse.\n"
+   ],
+   "metadata": {},
+   "id": "e8dbd93d-5340-479e-838b-49d277bcca7b"
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "from pyspark.sql import functions as F\n",
+    "from pyspark.sql.types import (\n",
+    "    StructType, StructField, StringType, ArrayType\n",
+    ")\n",
+    "\n",
+    "audit_schema = StructType([\n",
+    "    StructField('CreationTime', StringType()),\n",
+    "    StructField('UserId', StringType()),\n",
+    "    StructField('Workload', StringType()),\n",
+    "    StructField('ApplicationName', StringType()),\n",
+    "    StructField('ClientRegion', StringType()),\n",
+    "    StructField('AgentId', StringType()),\n",
+    "    StructField('AgentName', StringType()),\n",
+    "    StructField('AppIdentity', StructType([\n",
+    "        StructField('AppId', StringType()),\n",
+    "        StructField('DisplayName', StringType()),\n",
+    "        StructField('PublisherId', StringType()),\n",
+    "    ])),\n",
+    "    StructField('CopilotEventData', StructType([\n",
+    "        StructField('AppHost', StringType()),\n",
+    "        StructField('ThreadId', StringType()),\n",
+    "        StructField('SensitivityLabelId', StringType()),\n",
+    "        StructField('Contexts', ArrayType(StructType([\n",
+    "            StructField('Type', StringType())\n",
+    "        ]))),\n",
+    "        StructField('AISystemPlugin', ArrayType(StructType([\n",
+    "            StructField('Id', StringType()),\n",
+    "            StructField('Name', StringType())\n",
+    "        ]))),\n",
+    "        StructField('ModelTransparencyDetails', ArrayType(StructType([\n",
+    "            StructField('ModelName', StringType())\n",
+    "        ]))),\n",
+    "        StructField('AccessedResources', ArrayType(StructType([\n",
+    "            StructField('Type', StringType()),\n",
+    "            StructField('Action', StringType()),\n",
+    "            StructField('SiteUrl', StringType()),\n",
+    "            StructField('SensitivityLabelId', StringType()),\n",
+    "        ]))),\n",
+    "        StructField('Messages', ArrayType(StructType([\n",
+    "            StructField('Id', StringType()),\n",
+    "            StructField('isPrompt', StringType())\n",
+    "        ]))),\n",
+    "    ])),\n",
+    "])"
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.livy.statement-meta+json": {
+       "spark_pool": null,
+       "statement_id": 7,
+       "statement_ids": [
+        7
+       ],
+       "state": "finished",
+       "livy_statement_state": "available",
+       "spark_jobs_updating": false,
+       "session_id": "4f5617cc-9be1-4d31-be0d-4859fa4772f9",
+       "normalized_state": "finished",
+       "queued_time": "2026-04-30T17:54:56.0935546Z",
+       "session_start_time": null,
+       "execution_start_time": "2026-04-30T17:54:56.2545613Z",
+       "execution_finish_time": "2026-04-30T17:54:56.5230627Z",
+       "parent_msg_id": "9efcd0a5-08cf-45b3-a9a8-6dddd2a48f1b"
+      },
+      "text/plain": "StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 7, Finished, Available, Finished, False)"
+     },
+     "metadata": {}
+    }
+   ],
+   "execution_count": 5,
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "synapse_pyspark"
+    }
+   },
+   "id": "ada002dd-9755-478f-bd8c-e6fe279393c8"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## 3. Read raw CSVs and parse JSON\n"
+   ],
+   "metadata": {},
+   "id": "8eeef224-0348-4f4a-860c-63cbeac245e0"
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "raw = (spark.read\n",
+    "    .option('header', 'true')\n",
+    "    .option('multiline', 'true')\n",
+    "    .option('escape', '\"')\n",
+    "    .csv(RAW_PATH))\n",
+    "\n",
+    "print(f'Raw rows: {raw.count():,}')\n",
+    "\n",
+    "parsed = (raw\n",
+    "    .filter(F.col('AuditData').isNotNull() & (F.length('AuditData') > 10))\n",
+    "    .withColumn('j', F.from_json('AuditData', audit_schema))\n",
+    "    .filter(F.col('j').isNotNull()))\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.livy.statement-meta+json": {
+       "spark_pool": null,
+       "statement_id": 8,
+       "statement_ids": [
+        8
+       ],
+       "state": "finished",
+       "livy_statement_state": "available",
+       "spark_jobs_updating": false,
+       "session_id": "4f5617cc-9be1-4d31-be0d-4859fa4772f9",
+       "normalized_state": "finished",
+       "queued_time": "2026-04-30T17:54:56.4001378Z",
+       "session_start_time": null,
+       "execution_start_time": "2026-04-30T17:54:56.5250175Z",
+       "execution_finish_time": "2026-04-30T17:55:09.7063546Z",
+       "parent_msg_id": "f5e574b3-9bec-49ea-93e9-5d9286317fbb"
+      },
+      "text/plain": "StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 8, Finished, Available, Finished, False)"
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Raw rows: 376,556\n"
+     ]
+    }
+   ],
+   "execution_count": 6,
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "synapse_pyspark"
+    }
+   },
+   "id": "c60d5d63-7416-4129-93c4-56b287990462"
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "# Inspect distinct isPrompt values and a sample Messages structure\n",
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "print(\"Distinct isPrompt values:\")\n",
+    "parsed.selectExpr(\"explode(j.CopilotEventData.Messages) as msg\") \\\n",
+    "      .select(\"msg.isPrompt\") \\\n",
+    "      .distinct() \\\n",
+    "      .show(50, truncate=False)\n",
+    "\n",
+    "print(\"Sample Messages structures:\")\n",
+    "parsed.select(F.col(\"j.CopilotEventData.Messages\").alias(\"Messages\")).show(5, truncate=False)"
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.livy.statement-meta+json": {
+       "spark_pool": null,
+       "statement_id": 16,
+       "statement_ids": [
+        16
+       ],
+       "state": "finished",
+       "livy_statement_state": "available",
+       "spark_jobs_updating": false,
+       "session_id": "4f5617cc-9be1-4d31-be0d-4859fa4772f9",
+       "normalized_state": "finished",
+       "queued_time": "2026-04-30T18:07:30.1822247Z",
+       "session_start_time": null,
+       "execution_start_time": "2026-04-30T18:07:30.1834301Z",
+       "execution_finish_time": "2026-04-30T18:07:53.912016Z",
+       "parent_msg_id": "3c6ac2f9-4ba9-47a3-b8c7-cfc8edf1a992"
+      },
+      "text/plain": "StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 16, Finished, Available, Finished, False)"
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Distinct isPrompt values:\n+--------+\n|isPrompt|\n+--------+\n|false   |\n|true    |\n+--------+\n\nSample Messages structures:\n+-----------------------------------------------------------------------+\n|Messages                                                               |\n+-----------------------------------------------------------------------+\n|[{1749140036296, true}, {1749140036456, false}, {1749140036561, false}]|\n|[{1748449582440, true}, {1748449582582, false}]                        |\n|[{1742566321800, true}, {1742566321854, false}]                        |\n|[{1748945344625, true}, {1748945344776, false}]                        |\n|[{1744366239847, true}, {1744366239992, false}]                        |\n+-----------------------------------------------------------------------+\nonly showing top 5 rows\n\n"
+     ]
+    }
+   ],
+   "execution_count": 14,
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "synapse_pyspark"
+    },
+    "metadata": {
+     "microsoft": {
+      "language": "python",
+      "language_group": "synapse_pyspark"
+     }
+    },
+    "advisor": {
+     "adviceMetadata": "{\"artifactId\":\"f19458c8-258e-412f-98cd-3291e495d406\",\"activityId\":\"4f5617cc-9be1-4d31-be0d-4859fa4772f9\",\"applicationId\":\"application_1777570835767_0001\",\"jobGroupId\":\"16\",\"advices\":{\"info\":1}}"
+    }
+   },
+   "id": "1cbe71a4-43b5-4fbc-8971-7904295c15ee"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## 4. Flatten + fan out per (prompt × resource)\n",
+    "Mirrors the existing AI-in-One M-query exactly — drop responses, expand resources.\n"
+   ],
+   "metadata": {},
+   "id": "f954fa80-31e3-42b4-b3a9-0f638d430b6b"
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "from pyspark.sql.types import StringType\n",
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "# Flatten and fan out per (prompt × resource)\n",
+    "flat = (\n",
+    "    parsed\n",
+    "    .select(\n",
+    "        F.col('j.CreationTime').cast('timestamp').alias('CreationDate'),\n",
+    "        F.col('j.AgentId').alias('AgentId'),\n",
+    "        F.col('j.AgentName').alias('AgentName'),\n",
+    "        F.col('j.AppIdentity.AppId').alias('AppIdentity_AppId'),\n",
+    "        F.col('j.AppIdentity.DisplayName').alias('AppIdentity_DisplayName'),\n",
+    "        F.col('j.AppIdentity.PublisherId').alias('AppIdentity_PublisherId'),\n",
+    "        F.col('j.ApplicationName').alias('ApplicationName'),\n",
+    "        F.col('j.ClientRegion').alias('ClientRegion'),\n",
+    "        F.col('j.UserId').alias('Audit_UserId'),\n",
+    "        F.lower(F.trim(F.col('j.UserId'))).alias('Audit_UserId_Normalized'),\n",
+    "        F.col('j.Workload').alias('Workload'),\n",
+    "        F.col('j.CopilotEventData.AppHost').alias('AppHost'),\n",
+    "        F.col('j.CopilotEventData.ThreadId').alias('ThreadId'),\n",
+    "        F.col('j.CopilotEventData.SensitivityLabelId').alias('SensitivityLabelId'),\n",
+    "        F.col('j.CopilotEventData.Contexts')[0]['Type'].alias('Context_Type'),\n",
+    "        # Corrected bracket/parenthesis and keep first AISystemPlugin element\n",
+    "        F.col('j.CopilotEventData.AISystemPlugin')[0]['Id'].alias('AISystemPlugin_Id'),\n",
+    "        F.col('j.CopilotEventData.AISystemPlugin')[0]['Name'].alias('AISystemPlugin_Name'),\n",
+    "        F.col('j.CopilotEventData.ModelTransparencyDetails')[0]['ModelName']\n",
+    "            .alias('ModelTransparencyDetails_ModelName'),\n",
+    "        F.col('j.CopilotEventData.AccessedResources').alias('Resources'),\n",
+    "        F.col('j.CopilotEventData.Messages').alias('Messages'),\n",
+    "        F.size('j.CopilotEventData.AccessedResources').alias('Resource_Count'),\n",
+    "    )\n",
+    "    # One row per message\n",
+    "    .withColumn('msg', F.explode('Messages'))\n",
+    "    # Your data has isPrompt as true/false; cast to string and compare case-insensitively\n",
+    "    .filter(F.lower(F.col('msg.isPrompt').cast('string')) == 'true')\n",
+    "    # One row per accessed resource; if none, synthesize a single null resource\n",
+    "    .withColumn(\n",
+    "        'res',\n",
+    "        F.explode_outer(\n",
+    "            F.when(F.size('Resources') > 0, F.col('Resources'))\n",
+    "             .otherwise(F.array(F.struct(\n",
+    "                 F.lit(None).cast(StringType()).alias('Type'),\n",
+    "                 F.lit(None).cast(StringType()).alias('Action'),\n",
+    "                 F.lit(None).cast(StringType()).alias('SiteUrl'),\n",
+    "                 F.lit(None).cast(StringType()).alias('SensitivityLabelId'),\n",
+    "             )))\n",
+    "        ),\n",
+    "    )\n",
+    "    .select(\n",
+    "        'CreationDate', 'AgentId', 'AgentName',\n",
+    "        'AppIdentity_AppId', 'AppIdentity_DisplayName', 'AppIdentity_PublisherId',\n",
+    "        'ApplicationName', 'ClientRegion',\n",
+    "        'Audit_UserId', 'Audit_UserId_Normalized', 'Workload',\n",
+    "        'AppHost', 'ThreadId', 'SensitivityLabelId',\n",
+    "        'Context_Type',\n",
+    "        'AISystemPlugin_Id', 'AISystemPlugin_Name',\n",
+    "        'ModelTransparencyDetails_ModelName',\n",
+    "        F.col('res.Type').alias('AccessedResource_Type'),\n",
+    "        F.col('res.Action').alias('AccessedResource_Action'),\n",
+    "        F.col('res.SiteUrl').alias('AccessedResource_SiteUrl'),\n",
+    "        F.col('res.SensitivityLabelId').alias('AccessedResource_SensitivityLabelId'),\n",
+    "        F.col('msg.Id').alias('Message_Id'),\n",
+    "        F.col('msg.isPrompt').alias('Message_isPrompt'),\n",
+    "        F.coalesce(F.col('Resource_Count'), F.lit(1)).alias('Resource_Count'),\n",
+    "        F.to_date('CreationDate').alias('InteractionDate'),\n",
+    "        F.expr(\"date_trunc('week', CreationDate)\").cast('date').alias('WeekStart'),\n",
+    "        F.expr(\"date_trunc('month', CreationDate)\").cast('date').alias('MonthStart'),\n",
+    "    )\n",
+    ")"
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.livy.statement-meta+json": {
+       "spark_pool": null,
+       "statement_id": 19,
+       "statement_ids": [
+        19
+       ],
+       "state": "finished",
+       "livy_statement_state": "available",
+       "spark_jobs_updating": false,
+       "session_id": "4f5617cc-9be1-4d31-be0d-4859fa4772f9",
+       "normalized_state": "finished",
+       "queued_time": "2026-04-30T18:11:40.4546256Z",
+       "session_start_time": null,
+       "execution_start_time": "2026-04-30T18:11:40.456382Z",
+       "execution_finish_time": "2026-04-30T18:11:41.2191782Z",
+       "parent_msg_id": "50a8e6cc-ed15-4ff9-92be-98562da33608"
+      },
+      "text/plain": "StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 19, Finished, Available, Finished, False)"
+     },
+     "metadata": {}
+    }
+   ],
+   "execution_count": 17,
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "synapse_pyspark"
+    }
+   },
+   "id": "d27db198-8937-45f6-9f1e-3b508a911ffb"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## 5. Derive `Agent_TitleID`\n",
+    "Same logic as the M-query: pull the slug after the standard CopilotStudio prefix or before the first `.` for `P_` / `T_` declarative IDs.\n"
+   ],
+   "metadata": {},
+   "id": "70467f52-f89a-4699-8835-a42b1b52048c"
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "flat = flat.withColumn('Agent_TitleID', F.expr(r'''\n",
+    "    CASE\n",
+    "      WHEN AgentId IS NULL THEN NULL\n",
+    "      WHEN AgentId LIKE '%CopilotStudio.Declarative.%' THEN\n",
+    "           split(split(AgentId, 'CopilotStudio\\\\.Declarative\\\\.')[1], '\\\\.')[0]\n",
+    "      WHEN AgentId LIKE 'P\\\\_%' OR AgentId LIKE 'T\\\\_%' THEN\n",
+    "           split(AgentId, '\\\\.')[0]\n",
+    "      ELSE NULL\n",
+    "    END\n",
+    "'''))\n"
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.livy.statement-meta+json": {
+       "spark_pool": null,
+       "statement_id": 20,
+       "statement_ids": [
+        20
+       ],
+       "state": "finished",
+       "livy_statement_state": "available",
+       "spark_jobs_updating": false,
+       "session_id": "4f5617cc-9be1-4d31-be0d-4859fa4772f9",
+       "normalized_state": "finished",
+       "queued_time": "2026-04-30T18:11:49.9474622Z",
+       "session_start_time": null,
+       "execution_start_time": "2026-04-30T18:11:49.9486798Z",
+       "execution_finish_time": "2026-04-30T18:11:50.179367Z",
+       "parent_msg_id": "5edda97b-473b-49e8-839c-50cb484e0da2"
+      },
+      "text/plain": "StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 20, Finished, Available, Finished, False)"
+     },
+     "metadata": {}
+    }
+   ],
+   "execution_count": 18,
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "synapse_pyspark"
+    }
+   },
+   "id": "a64ee3a1-bd87-417c-8e97-de04e4f15fb4"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## 6. Write to Lakehouse Delta table\n"
+   ],
+   "metadata": {},
+   "id": "7cecb9f8-d6e9-40ca-834f-3d7652da2007"
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "(flat.write\n",
+    "    .format('delta')\n",
+    "    .mode(WRITE_MODE)\n",
+    "    .option('overwriteSchema', 'true')\n",
+    "    .saveAsTable(OUTPUT_TABLE))\n",
+    "\n",
+    "print(f'Rows written to {OUTPUT_TABLE}: {spark.table(OUTPUT_TABLE).count():,}')"
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.livy.statement-meta+json": {
+       "spark_pool": null,
+       "statement_id": 21,
+       "statement_ids": [
+        21
+       ],
+       "state": "finished",
+       "livy_statement_state": "available",
+       "spark_jobs_updating": false,
+       "session_id": "4f5617cc-9be1-4d31-be0d-4859fa4772f9",
+       "normalized_state": "finished",
+       "queued_time": "2026-04-30T18:11:56.1988544Z",
+       "session_start_time": null,
+       "execution_start_time": "2026-04-30T18:11:56.1999621Z",
+       "execution_finish_time": "2026-04-30T18:12:30.2177326Z",
+       "parent_msg_id": "e56a58ca-b3d4-46b7-b2e7-73cbcde1f46d"
+      },
+      "text/plain": "StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 21, Finished, Available, Finished, False)"
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Rows written to Copilot_Interactions_Parsed: 782,397\n"
+     ]
+    }
+   ],
+   "execution_count": 19,
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "synapse_pyspark"
+    },
+    "advisor": {
+     "adviceMetadata": "{\"artifactId\":\"f19458c8-258e-412f-98cd-3291e495d406\",\"activityId\":\"4f5617cc-9be1-4d31-be0d-4859fa4772f9\",\"applicationId\":\"application_1777570835767_0001\",\"jobGroupId\":\"21\",\"advices\":{\"info\":1}}"
+    }
+   },
+   "id": "deddee2b-d91b-4a33-b9a9-4de3b895810b"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## 7. Verify\n",
+    "Spot-check the output. Expect populated `AISystemPlugin_Id` (e.g. `BingWebSearch`), `Workload`, `AppHost`, etc.\n"
+   ],
+   "metadata": {},
+   "id": "8fc21017-b971-4e4f-a815-26a1c1c7d485"
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "spark.table(OUTPUT_TABLE).select(\n",
+    "    'AISystemPlugin_Id', 'Workload', 'AppHost'\n",
+    ").groupBy('AISystemPlugin_Id', 'Workload', 'AppHost').count().orderBy(F.desc('count')).show(20, truncate=False)"
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "application/vnd.livy.statement-meta+json": {
+       "spark_pool": null,
+       "statement_id": 22,
+       "statement_ids": [
+        22
+       ],
+       "state": "finished",
+       "livy_statement_state": "available",
+       "spark_jobs_updating": false,
+       "session_id": "4f5617cc-9be1-4d31-be0d-4859fa4772f9",
+       "normalized_state": "finished",
+       "queued_time": "2026-04-30T18:12:39.6638934Z",
+       "session_start_time": null,
+       "execution_start_time": "2026-04-30T18:12:39.6650301Z",
+       "execution_finish_time": "2026-04-30T18:12:42.756856Z",
+       "parent_msg_id": "2473c213-edc2-4216-abea-79deb4822bc3"
+      },
+      "text/plain": "StatementMeta(, 4f5617cc-9be1-4d31-be0d-4859fa4772f9, 22, Finished, Available, Finished, False)"
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "+-----------------+--------+--------------+------+\n|AISystemPlugin_Id|Workload|AppHost       |count |\n+-----------------+--------+--------------+------+\n|BingWebSearch    |Copilot |Teams         |327659|\n|BingWebSearch    |Copilot |Office        |240731|\n|NULL             |Copilot |Outlook       |71106 |\n|NULL             |Copilot |Word          |34380 |\n|BingWebSearch    |Copilot |Outlook       |23122 |\n|NULL             |Copilot |Teams         |15682 |\n|NULL             |Copilot |Unknown       |14632 |\n|NULL             |Copilot |Office        |12773 |\n|NULL             |Copilot |PowerPoint    |6630  |\n|EnterpriseSearch |Copilot |Teams         |5533  |\n|NULL             |Copilot |Excel         |5456  |\n|NULL             |Copilot |Copilot Studio|4721  |\n|NULL             |Copilot |Forms         |3279  |\n|NULL             |Copilot |Designer      |3234  |\n|BingWebSearch    |Copilot |Edge          |1649  |\n|NULL             |Copilot |Autonomous    |1469  |\n|NULL             |Copilot |OneNote       |1400  |\n|EnterpriseSearch |Copilot |Stream        |1160  |\n|BingWebSearch    |Copilot |Word          |1144  |\n|NULL             |Copilot |SharePoint    |891   |\n+-----------------+--------+--------------+------+\nonly showing top 20 rows\n\n"
+     ]
+    }
+   ],
+   "execution_count": 20,
+   "metadata": {
+    "microsoft": {
+     "language": "python",
+     "language_group": "synapse_pyspark"
+    }
+   },
+   "id": "1459a03f-da19-4d55-aedb-fe9f1009ea23"
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "---\n",
+    "**Connect the PBIT**: open the **Fabric variant** of the AI-in-One or AI Business Value Dashboard PBIT, supply two parameters when prompted:\n",
+    "- `Fabric SQL Endpoint` = `<workspace-guid>.datawarehouse.fabric.microsoft.com` (find in Lakehouse settings → SQL endpoint)\n",
+    "- `Lakehouse Database` = the lakehouse name (e.g. `CopilotAnalytics`)\n",
+    "\n",
+    "The PBIT will source `dbo.Copilot_Interactions_Parsed` directly. Refresh becomes a near-instant data copy (or zero-copy with Direct Lake mode).\n"
+   ],
+   "metadata": {},
+   "id": "0ff75101-1a0e-411e-bccb-19dfc5821f54"
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "kernel_info": {
+   "name": "synapse_pyspark"
+  },
+  "kernelspec": {
+   "display_name": "Synapse PySpark",
+   "language": "Python",
+   "name": "synapse_pyspark"
+  },
+  "a365ComputeOptions": null,
+  "sessionKeepAliveTimeout": 0,
+  "microsoft": {
+   "language": "python",
+   "language_group": "synapse_pyspark",
+   "ms_spell_check": {
+    "ms_spell_check_language": "en"
+   }
+  },
+  "nteract": {
+   "version": "nteract-front-end@1.0.0"
+  },
+  "spark_compute": {
+   "compute_id": "/trident/default",
+   "session_options": {
+    "conf": {
+     "spark.synapse.nbs.session.timeout": "1200000"
+    }
+   }
+  },
+  "dependencies": {
+   "lakehouse": {
+    "default_lakehouse": "eb233254-0200-4793-822c-a1ddb4a5cc2c",
+    "default_lakehouse_name": "CopilotAnalytics",
+    "default_lakehouse_workspace_id": "46590cf4-e16c-402e-a2b2-13e3e8c69b2e",
+    "known_lakehouses": [
+     {
+      "id": "eb233254-0200-4793-822c-a1ddb4a5cc2c"
+     }
+    ]
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/3. Fabric/notebooks/Copilot_Licensed_Users_Loader.ipynb
+++ b/3. Fabric/notebooks/Copilot_Licensed_Users_Loader.ipynb
@@ -29,7 +29,7 @@
    "outputs": [],
    "source": [
     "RAW_PATH     = 'Files/licensed_raw/*.csv'         # raw licence-export CSVs\n",
-    "OUTPUT_TABLE = 'copilot_licensed_users'           # Delta table consumed by the PBIT\n",
+    "OUTPUT_TABLE = 'dbo.copilot_licensed_users'           # Delta table consumed by the PBIT\n",
     "WRITE_MODE   = 'overwrite'                        # 'overwrite' for full snapshots; switch to 'append' if appending"
    ]
   },

--- a/3. Fabric/notebooks/Copilot_Org_Data_Loader.ipynb
+++ b/3. Fabric/notebooks/Copilot_Org_Data_Loader.ipynb
@@ -29,7 +29,7 @@
    "outputs": [],
    "source": [
     "RAW_PATH     = 'Files/org_raw/*.csv'      # raw HRIS/Entra org-data CSVs\n",
-    "OUTPUT_TABLE = 'copilot_org_data'         # Delta table consumed by the PBIT\n",
+    "OUTPUT_TABLE = 'dbo.copilot_org_data'         # Delta table consumed by the PBIT\n",
     "WRITE_MODE   = 'overwrite'                # 'overwrite' for full snapshots"
    ]
   },


### PR DESCRIPTION
Lakehouse Schemas mode is now the Fabric default, which means saveAsTable('Copilot_Interactions_Parsed') without a schema prefix fails or lands in an unexpected location. Prefix all 3 OUTPUT_TABLE constants with 'dbo.' so the legacy CSV loaders behave the same as the new Direct Ingesters and write to dbo.<table> consistently.

Affected:
  - Copilot_Audit_Log_Parser.ipynb       (Copilot_Interactions_Parsed)
  - Copilot_Licensed_Users_Loader.ipynb  (copilot_licensed_users)
  - Copilot_Org_Data_Loader.ipynb        (copilot_org_data)

No behaviour change for legacy non-schema Lakehouses ('dbo' is the implicit default schema either way).