### PR TITLE
Remove Tier 1 Git-integration reference from pipelines README

### DIFF
--- a/3. Fabric/pipelines/README.md
+++ b/3. Fabric/pipelines/README.md
@@ -2,7 +2,7 @@
 
 Scheduled orchestration for the Direct Ingester notebooks. Two ways to use:
 
-## Option A — Manual deployment (works today)
+## Deployment
 
 1. **Import the 3 notebooks** into your Fabric workspace first (one-time):
    - `3. Fabric/notebooks/Copilot_Audit_Log_Direct_Ingester.ipynb`
@@ -29,12 +29,6 @@ Scheduled orchestration for the Direct Ingester notebooks. Two ways to use:
 4. **Run manually first** to validate: pipeline editor → **Run** at top. Should kick off the 3 notebooks in parallel. Audit log activity typically runs 5–15 min (Purview polling); users + org each <30 sec.
 
 5. **Schedule it**: pipeline editor → **Schedule** at top → e.g. weekly Sunday 02:00. Activities run on the same cadence.
-
-## Option B — Tier 1 Fabric Git Integration (in development)
-
-The Tier 1 work-in-progress will make this pipeline plus the 3 notebooks deployable via Fabric Git Sync — customer connects their workspace to this repo's branch, clicks Sync, all items appear. No manual GUID-swapping. See `Automation Scripts/Tier 1 — Fabric Git Integration Plan.md` for the build plan.
-
-Until Tier 1 ships, Option A above is the working approach.
 
 ## Activity design notes
 


### PR DESCRIPTION
Tier 1 is still in development. Keeping the customer-facing pipelines README focused on the working deployment approach. The Tier 1 plan remains tracked in OneDrive (Automation Scripts/Tier 1 — Fabric Git Integration Plan.md) for internal reference but isn't customer-ready yet.

Also drop the now-redundant "Option A — Manual deployment" header since there's no Option B to contrast with.