### PR TITLE
Fix undefined $existingAssignments bug in Folder/azure + Legacy/azure…

### DIFF
--- a/2. SharePoint/Folder/azure/apply-permissions.ps1
+++ b/2. SharePoint/Folder/azure/apply-permissions.ps1
@@ -88,7 +88,7 @@ function TryAssignRoles($principalId, $servicePrincipal, $appRoleValue) {
     $sitesSelectedRole = $servicePrincipal.AppRoles | Where-Object {
         $_.Value -eq $appRoleValue -and $_.AllowedMemberTypes -contains "Application"
     }
-    if ($sitesSelectedRole -and -not (Test-RoleAssigned $sitesSelectedRole.Id $servicePrincipal.Id $existingAssignments)) {
+    if ($sitesSelectedRole -and -not (Test-RoleAssigned $sitesSelectedRole.Id $servicePrincipal.Id $principalId)) {
         $newRole = New-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $principalId `
             -PrincipalId $principalId `
             -ResourceId $servicePrincipal.Id `
@@ -96,7 +96,15 @@ function TryAssignRoles($principalId, $servicePrincipal, $appRoleValue) {
     }
 }
 
-function Test-RoleAssigned($roleId, $resourceId, $assignments) {
+# Helper function to check if role is already assigned. Fetches the principal's
+# current assignments inline so we never reference an undefined caller-scope variable.
+function Test-RoleAssigned($roleId, $resourceId, $principalId) {
+    try {
+        $assignments = Get-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $principalId -All -ErrorAction Stop
+    }
+    catch {
+        return $null
+    }
     return $assignments | Where-Object {
         $_.AppRoleId -eq $roleId -and $_.ResourceId -eq $resourceId
     }

--- a/2. SharePoint/Folder/azure/deploy.ps1
+++ b/2. SharePoint/Folder/azure/deploy.ps1
@@ -103,7 +103,7 @@ function TryAssignRoles($principalId, $servicePrincipal, $appRoleValue) {
     $sitesSelectedRole = $servicePrincipal.AppRoles | Where-Object {
         $_.Value -eq $appRoleValue -and $_.AllowedMemberTypes -contains "Application"
     }
-    if ($sitesSelectedRole -and -not (Test-RoleAssigned $sitesSelectedRole.Id $servicePrincipal.Id $existingAssignments)) {
+    if ($sitesSelectedRole -and -not (Test-RoleAssigned $sitesSelectedRole.Id $servicePrincipal.Id $principalId)) {
         $newRole = New-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $principalId `
             -PrincipalId $principalId `
             -ResourceId $servicePrincipal.Id `
@@ -111,8 +111,15 @@ function TryAssignRoles($principalId, $servicePrincipal, $appRoleValue) {
     }
 }
 
-# Helper function to check if role is already assigned
-function Test-RoleAssigned($roleId, $resourceId, $assignments) {
+# Helper function to check if role is already assigned. Fetches the principal's
+# current assignments inline so we never reference an undefined caller-scope variable.
+function Test-RoleAssigned($roleId, $resourceId, $principalId) {
+    try {
+        $assignments = Get-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $principalId -All -ErrorAction Stop
+    }
+    catch {
+        return $null
+    }
     return $assignments | Where-Object {
         $_.AppRoleId -eq $roleId -and $_.ResourceId -eq $resourceId
     }

--- a/2. SharePoint/Legacy/azure/apply-permissions.ps1
+++ b/2. SharePoint/Legacy/azure/apply-permissions.ps1
@@ -88,7 +88,7 @@ function TryAssignRoles($principalId, $servicePrincipal, $appRoleValue) {
     $sitesSelectedRole = $servicePrincipal.AppRoles | Where-Object {
         $_.Value -eq $appRoleValue -and $_.AllowedMemberTypes -contains "Application"
     }
-    if ($sitesSelectedRole -and -not (Test-RoleAssigned $sitesSelectedRole.Id $servicePrincipal.Id $existingAssignments)) {
+    if ($sitesSelectedRole -and -not (Test-RoleAssigned $sitesSelectedRole.Id $servicePrincipal.Id $principalId)) {
         $newRole = New-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $principalId `
             -PrincipalId $principalId `
             -ResourceId $servicePrincipal.Id `
@@ -96,7 +96,15 @@ function TryAssignRoles($principalId, $servicePrincipal, $appRoleValue) {
     }
 }
 
-function Test-RoleAssigned($roleId, $resourceId, $assignments) {
+# Helper function to check if role is already assigned. Fetches the principal's
+# current assignments inline so we never reference an undefined caller-scope variable.
+function Test-RoleAssigned($roleId, $resourceId, $principalId) {
+    try {
+        $assignments = Get-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $principalId -All -ErrorAction Stop
+    }
+    catch {
+        return $null
+    }
     return $assignments | Where-Object {
         $_.AppRoleId -eq $roleId -and $_.ResourceId -eq $resourceId
     }

--- a/2. SharePoint/Legacy/azure/deploy.ps1
+++ b/2. SharePoint/Legacy/azure/deploy.ps1
@@ -103,7 +103,7 @@ function TryAssignRoles($principalId, $servicePrincipal, $appRoleValue) {
     $sitesSelectedRole = $servicePrincipal.AppRoles | Where-Object {
         $_.Value -eq $appRoleValue -and $_.AllowedMemberTypes -contains "Application"
     }
-    if ($sitesSelectedRole -and -not (Test-RoleAssigned $sitesSelectedRole.Id $servicePrincipal.Id $existingAssignments)) {
+    if ($sitesSelectedRole -and -not (Test-RoleAssigned $sitesSelectedRole.Id $servicePrincipal.Id $principalId)) {
         $newRole = New-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $principalId `
             -PrincipalId $principalId `
             -ResourceId $servicePrincipal.Id `
@@ -111,8 +111,15 @@ function TryAssignRoles($principalId, $servicePrincipal, $appRoleValue) {
     }
 }
 
-# Helper function to check if role is already assigned
-function Test-RoleAssigned($roleId, $resourceId, $assignments) {
+# Helper function to check if role is already assigned. Fetches the principal's
+# current assignments inline so we never reference an undefined caller-scope variable.
+function Test-RoleAssigned($roleId, $resourceId, $principalId) {
+    try {
+        $assignments = Get-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $principalId -All -ErrorAction Stop
+    }
+    catch {
+        return $null
+    }
     return $assignments | Where-Object {
         $_.AppRoleId -eq $roleId -and $_.ResourceId -eq $resourceId
     }


### PR DESCRIPTION
… scripts

The TryAssignRoles function referenced $existingAssignments — a variable that was never initialized in this scope (it existed in a different script, ProvisionPreReqs.ps1). At runtime this caused Test-RoleAssigned to receive $null instead of the assignments list, breaking the "is role already assigned" check.

File/azure/ already got this fix in commit 8fe6abf (parallel session's Bicep validation work). This commit propagates the same fix to Folder and Legacy paths, which had copies of the original (buggy) script.

Files fixed (4 per repo):
  - 2. SharePoint/Folder/azure/apply-permissions.ps1
  - 2. SharePoint/Folder/azure/deploy.ps1
  - 2. SharePoint/Legacy/azure/apply-permissions.ps1
  - 2. SharePoint/Legacy/azure/deploy.ps1

The fix: Test-RoleAssigned now fetches the principal's assignments inline via Get-MgServicePrincipalAppRoleAssignment, removing the caller-scope dependency entirely.