### PR TITLE
docs(fabric): schema-enabled lakehouse, correct audit scope, audit query tuning

### DIFF
--- a/Classic Editions/3. Fabric/README.md
+++ b/Classic Editions/3. Fabric/README.md
@@ -65,9 +65,12 @@ The PBIT exposes three parameters: **Fabric SQL Endpoint**, **Lakehouse Database
 Before running the notebooks, you need:
 
 1. **A Fabric workspace** assigned to a Fabric capacity (F2+ or trial), or Premium / PPU.
-2. **A Lakehouse** in that workspace (any name; `CopilotAnalytics` is the convention used in examples).
+2. **A Lakehouse** in that workspace, created with **schemas enabled** (any name; `CopilotAnalytics` is the convention used in examples).
+
+   > ⚠️ **The Lakehouse must be schema-enabled.** All three notebooks write with `saveAsTable('dbo.<table>')`, and a Lakehouse created without schema support has no `dbo` schema in Spark. Every notebook then fails with `System cancelled the Spark session due to statement execution failures`, which mentions neither the schema nor the table. Tick **Lakehouse schemas** in the creation dialog, or pass `creationPayload: { enableSchemas: true }` if you create it via the Fabric REST API.
+
 3. **An Entra app registration** with these Microsoft Graph **application** permissions (admin consent required):
-   - `AuditLog.Read.All` — for the audit log notebook
+   - `AuditLogsQuery.Read.All` — for the audit log notebook, which queries the Purview audit API (`/security/auditLog/queries`). This is **not** the Entra `AuditLog.Read.All` scope, which the notebook never calls.
    - `Reports.Read.All` — for the licensed users notebook
    - `User.Read.All` — for the org data notebook
    Grab three values: **Tenant ID**, **Application (client) ID**, **Client secret value** (not Secret ID).
@@ -79,7 +82,7 @@ Helper scripts for app-registration setup live in [`archive/scripts/appreg/`](ar
 ### 1. Stand up the Lakehouse
 
 - Open a Fabric workspace assigned to a Fabric capacity (F2+ or trial)
-- **+ New → Lakehouse**, name it (e.g. `CopilotAnalytics`)
+- **+ New → Lakehouse**, name it (e.g. `CopilotAnalytics`), and **enable Lakehouse schemas** — the notebooks write to `dbo.*` and will fail without it (see [Prerequisites](#prerequisites))
 - Note the **SQL endpoint** under Lakehouse settings — looks like `<workspace-guid>.datawarehouse.fabric.microsoft.com`
 
 ### 2. Import and configure the three Direct Ingester notebooks
@@ -184,7 +187,9 @@ If you have an existing pipeline that produces parsed CSVs (matching the three D
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `401 Unauthorized` from Graph in cell 2 | App reg secret expired or permissions not consented | Regenerate the secret in Entra; confirm admin consent is granted on all three Graph application permissions |
-| `403 Forbidden` from `/auditLog/auditLogQueries` | App reg missing `AuditLog.Read.All` (Application, not Delegated) | Add the application permission, grant admin consent, regenerate token |
+| `System cancelled the Spark session due to statement execution failures` on **every** notebook | The Lakehouse was created without schemas, so `saveAsTable('dbo.<table>')` has no `dbo` schema to write into. The message names neither the schema nor the table | Recreate the Lakehouse with **schemas enabled** (see [Prerequisites](#prerequisites)) and re-run. Existing Lakehouses cannot be converted |
+| `403 Forbidden` from `/auditLog/auditLogQueries` | App reg missing `AuditLogsQuery.Read.All` (Application, not Delegated). Note this is the Purview audit scope — the Entra `AuditLog.Read.All` scope is a different permission and is not used by this notebook | Add `AuditLogsQuery.Read.All` as an application permission, grant admin consent, regenerate token |
+| `400 Client Error: Bad Request for url: .../security/auditLog/queries/<id>` | Too many concurrent Purview audit queries. The defaults split the lookback into `LOOKBACK_DAYS × 24 / CHUNK_HOURS` windows and run `MAX_CONCURRENT_QUERIES` at once — 7 days at the defaults is 21 windows, 6 at a time. The notebook raises on the first bad response rather than retrying that window | In cell 2, raise `CHUNK_HOURS` (e.g. `24`) and lower `MAX_CONCURRENT_QUERIES` (e.g. `2`). Fewer, wider windows are gentler on the API and just as complete |
 | Audit log query stays in `running` state forever | Tenant has a backlog of audit-log query jobs, or the date range is too wide | The notebook polls with backoff up to 30 min. If you hit the timeout, narrow `LOOKBACK_DAYS` in cell 2 |
 | `Login failed` / `cannot open database` (PBI side) | SQL endpoint hostname or database name wrong | Re-check Lakehouse settings page for the exact SQL endpoint string |
 | `the key didn't match any rows in the table` | A notebook ran against the wrong (non-default) Lakehouse, so the expected table name doesn't exist | In the notebook's Lakehouses panel, confirm your Lakehouse is **pinned** (📌) before re-running |


### PR DESCRIPTION
Three fixes to the Fabric deployment guide, all hit while deploying it end to end against a
real tenant.

**1. The Lakehouse must be created with schemas enabled** (#58)

All three Direct Ingester notebooks write via `saveAsTable('dbo.<table>')`. A Lakehouse
created without schema support has no `dbo` schema in Spark, so every notebook fails with
`System cancelled the Spark session due to statement execution failures` — a message that
names neither the schema nor the table. The guide previously said only
"+ New -> Lakehouse, name it". Verified: recreating the Lakehouse with
`creationPayload: { enableSchemas: true }`, changing nothing else, made all three notebooks
complete.

**2. The documented Graph permission was wrong** (#59)

The guide asked for `AuditLog.Read.All`, the Entra directory-audit scope. The audit notebook
calls `beta/security/auditLog/queries`, which needs `AuditLogsQuery.Read.All`. Following the
guide exactly produces a 403, and the troubleshooting table repeated the same wrong scope.

**3. The audit ingester's defaults exceed the audit query API** (#60)

`CHUNK_HOURS=8` with `MAX_CONCURRENT_QUERIES=6` turns a 7-day lookback into 21 windows six
at a time; the API returns `400` on `GET /security/auditLog/queries/<id>` and the notebook
raises on the first bad response, losing the whole run. Added as a troubleshooting entry
with values verified to work (`24` / `2`).

Docs-only; no notebook or template changes. Note that #60 also suggests changing the
shipped defaults and making a failed window non-fatal, which is a code change and is left
for the maintainers.